### PR TITLE
Change defaultSOCKSListenHost form 127.0.0.1 to 0.0.0.0

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -41,7 +41,7 @@ type Client struct {
 	wg       sync.WaitGroup
 }
 
-const defaultSOCKSListenHost = "127.0.0.1"
+const defaultSOCKSListenHost = "0.0.0.0"
 
 // Run starts the client and listens for SOCKS5 traffic.
 func Run(


### PR DESCRIPTION
Изменение чтобы было доступно на всех интерфейсах, если человек захочет использовать socks5 сервер из локальной сети