### PR TITLE
feat: add Android support and switch to Yandex DNS

### DIFF
--- a/cmd/olcrtc/main.go
+++ b/cmd/olcrtc/main.go
@@ -93,7 +93,7 @@ func parseFlags() config {
 	flag.StringVar(&cfg.keyHex, "key", "", "Shared encryption key (hex)")
 	flag.BoolVar(&cfg.debug, "debug", false, "Enable verbose logging")
 	flag.StringVar(&cfg.dataDir, "data", "data", "Path to data directory")
-	flag.StringVar(&cfg.dnsServer, "dns", "1.1.1.1:53", "DNS server (default: Cloudflare 1.1.1.1)")
+	flag.StringVar(&cfg.dnsServer, "dns", "77.88.8.8:53", "DNS server (default: Yandex 77.88.8.8)")
 	flag.StringVar(&cfg.socksProxyAddr, "socks-proxy", "", "SOCKS5 proxy address (server only)")
 	flag.IntVar(&cfg.socksProxyPort, "socks-proxy-port", 1080, "SOCKS5 proxy port (server only)")
 	flag.Parse()
@@ -169,6 +169,7 @@ func runMode(ctx context.Context, cfg config, errCh chan<- error) {
 			cfg.socksHost,
 			"",
 			"",
+			cfg.dnsServer,
 		)
 	}
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -51,9 +51,10 @@ func Run(
 	socksPort int,
 	socksHost,
 	socksUser,
-	socksPass string,
+	socksPass,
+	dnsServer string,
 ) error {
-	return RunWithReady(ctx, roomURL, keyHex, socksPort, socksHost, socksUser, socksPass, nil)
+	return RunWithReady(ctx, roomURL, keyHex, socksPort, socksHost, socksUser, socksPass, dnsServer, nil)
 }
 
 // RunWithReady starts the client and invokes onReady once the local SOCKS5 listener is accepting connections.
@@ -64,7 +65,8 @@ func RunWithReady(
 	socksPort int,
 	socksHost,
 	socksUser,
-	socksPass string,
+	socksPass,
+	dnsServer string,
 	onReady func(),
 ) error {
 	runCtx, cancel := context.WithCancel(ctx)
@@ -94,7 +96,7 @@ func RunWithReady(
 	c.mux = mux.New(c.clientID, c.sendFrame)
 
 	for peerID := range 1 {
-		if err := c.addPeer(runCtx, roomURL, peerID, cancel); err != nil {
+		if err := c.addPeer(runCtx, roomURL, peerID, dnsServer, cancel); err != nil {
 			return fmt.Errorf("addPeer failed: %w", err)
 		}
 	}
@@ -185,9 +187,10 @@ func (c *Client) addPeer(
 	runCtx context.Context,
 	roomURL string,
 	peerID int,
+	dnsServer string,
 	cancel context.CancelFunc,
 ) error {
-	peer, err := telemost.NewPeer(runCtx, roomURL, names.Generate(), c.onData)
+	peer, err := telemost.NewPeer(runCtx, roomURL, names.Generate(), dnsServer, c.onData)
 	if err != nil {
 		return fmt.Errorf("create peer %d: %w", peerID, err)
 	}

--- a/internal/protect/protect.go
+++ b/internal/protect/protect.go
@@ -31,19 +31,41 @@ func controlFunc(network, _ string, c syscall.RawConn) error {
 }
 
 // NewDialer returns a net.Dialer that calls Protector on each new socket.
-func NewDialer() *net.Dialer {
-	return &net.Dialer{
+func NewDialer(dnsServer string) *net.Dialer {
+	dialer := &net.Dialer{
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
 		Control:   controlFunc,
 	}
+
+	if dnsServer != "" {
+		dialer.Resolver = &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{
+					Timeout: 5 * time.Second,
+					Control: controlFunc,
+				}
+				// Force IPv4 for DNS lookups
+				return d.DialContext(ctx, "udp4", dnsServer)
+			},
+		}
+	}
+
+	return dialer
 }
 
-// NewHTTPClient returns an http.Client using protected sockets.
-func NewHTTPClient() *http.Client {
-	dialer := NewDialer()
+// NewHTTPClient returns an http.Client using protected sockets and optional DNS server.
+func NewHTTPClient(dnsServer string) *http.Client {
+	dialer := NewDialer(dnsServer)
 	transport := &http.Transport{
-		DialContext:           dialer.DialContext,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// Force IPv4 for all TCP connections to avoid broken IPv6 on Android
+			if network == "tcp" {
+				network = "tcp4"
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          10,
 		IdleConnTimeout:       30 * time.Second,
@@ -55,7 +77,7 @@ func NewHTTPClient() *http.Client {
 
 // DialContext dials using a protected socket.
 func DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	conn, err := NewDialer().DialContext(ctx, network, address)
+	conn, err := NewDialer("").DialContext(ctx, network, address)
 	if err != nil {
 		return nil, fmt.Errorf("dial failed: %w", err)
 	}
@@ -67,12 +89,13 @@ type ProxyDialer struct{}
 
 // Dial connects to the address on the named network using a protected socket.
 func (d *ProxyDialer) Dial(network, addr string) (net.Conn, error) {
-	conn, err := NewDialer().Dial(network, addr)
+	conn, err := NewDialer("").Dial(network, addr)
 	if err != nil {
 		return nil, fmt.Errorf("dial failed: %w", err)
 	}
 	return conn, nil
 }
+
 
 // NewProxyDialer returns a proxy.Dialer that protects ICE sockets.
 func NewProxyDialer() *ProxyDialer {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,7 +92,7 @@ func Run(
 	}
 
 	if s.dnsServer == "" {
-		s.dnsServer = "1.1.1.1:53"
+		s.dnsServer = "77.88.8.8:53"
 	}
 
 	s.setupResolver()
@@ -183,7 +183,7 @@ func (s *Server) setupMux() {
 }
 
 func (s *Server) addPeer(ctx context.Context, roomURL string, peerID int, cancel context.CancelFunc) error {
-	peer, err := telemost.NewPeer(ctx, roomURL, names.Generate(), s.onData)
+	peer, err := telemost.NewPeer(ctx, roomURL, names.Generate(), s.dnsServer, s.onData)
 	if err != nil {
 		return fmt.Errorf("failed to create peer: %w", err)
 	}

--- a/internal/telemost/api.go
+++ b/internal/telemost/api.go
@@ -26,7 +26,7 @@ type ConnectionInfo struct { //nolint:revive
 	} `json:"client_configuration"` //nolint:tagliatelle
 }
 
-func GetConnectionInfo(ctx context.Context, roomURL, displayName string) (*ConnectionInfo, error) { //nolint:revive
+func GetConnectionInfo(ctx context.Context, roomURL, displayName, dnsServer string) (*ConnectionInfo, error) { //nolint:revive
 	u := fmt.Sprintf("%s/conferences/%s/connection", apiBase, url.QueryEscape(roomURL))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
@@ -49,7 +49,7 @@ func GetConnectionInfo(ctx context.Context, roomURL, displayName string) (*Conne
 	req.Header.Set("Origin", "https://telemost.yandex.ru")
 	req.Header.Set("Referer", "https://telemost.yandex.ru/")
 
-	client := protect.NewHTTPClient()
+	client := protect.NewHTTPClient(dnsServer)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to do request: %w", err)

--- a/internal/telemost/peer.go
+++ b/internal/telemost/peer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand/v2"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -52,6 +53,7 @@ type TrafficShape struct { //nolint:revive
 type Peer struct { //nolint:revive
 	roomURL         string
 	name            string
+	dnsServer       string
 	conn            *ConnectionInfo
 	ws              *websocket.Conn
 	wsMu            sync.Mutex
@@ -106,8 +108,8 @@ func (p *Peer) SetTrafficShape(shape TrafficShape) { //nolint:revive
 	p.trafficShape = shape
 }
 
-func NewPeer(ctx context.Context, roomURL, name string, onData func([]byte)) (*Peer, error) { //nolint:revive
-	conn, err := GetConnectionInfo(ctx, roomURL, name)
+func NewPeer(ctx context.Context, roomURL, name, dnsServer string, onData func([]byte)) (*Peer, error) { //nolint:revive
+	conn, err := GetConnectionInfo(ctx, roomURL, name, dnsServer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connection info: %w", err)
 	}
@@ -115,6 +117,7 @@ func NewPeer(ctx context.Context, roomURL, name string, onData func([]byte)) (*P
 	return &Peer{
 		roomURL:        roomURL,
 		name:           name,
+		dnsServer:      dnsServer,
 		conn:           conn,
 		onData:         onData,
 		reconnectCh:    make(chan struct{}, 1),
@@ -301,7 +304,12 @@ func (p *Peer) onDataChannelMessage(msg webrtc.DataChannelMessage) {
 
 func (p *Peer) dialWebSocket() error {
 	wsDialer := websocket.Dialer{
-		NetDialContext:   protect.DialContext,
+		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if network == "tcp" {
+				network = "tcp4"
+			}
+			return protect.NewDialer(p.dnsServer).DialContext(ctx, network, addr)
+		},
 		HandshakeTimeout: 15 * time.Second,
 	}
 	ws, resp, err := wsDialer.Dial(p.conn.ClientConfig.MediaServerURL, nil)
@@ -727,7 +735,7 @@ func (p *Peer) sendTelemetry(ctx context.Context, endpoint, event string) {
 	req.Header.Set("X-Telemost-Client-Version", "187.1.0")
 	req.Header.Set("Idempotency-Key", uuid.New().String())
 
-	client := protect.NewHTTPClient()
+	client := protect.NewHTTPClient(p.dnsServer)
 	resp, err := client.Do(req)
 	if err != nil {
 		logger.Verbosef("Telemetry send error: %v", err)
@@ -964,7 +972,7 @@ func (p *Peer) reconnect(ctx context.Context) error {
 	}
 
 	time.Sleep(3 * time.Second)
-	conn, err := GetConnectionInfo(ctx, p.roomURL, p.name)
+	conn, err := GetConnectionInfo(ctx, p.roomURL, p.name, p.dnsServer)
 	if err != nil {
 		return fmt.Errorf("reconnect get info: %w", err)
 	}

--- a/ui/config.go
+++ b/ui/config.go
@@ -61,7 +61,7 @@ func (p *Program) loadConfig() *Config {
 	log("Loading config from: %s", configPath)
 	// default values
 	cfg := &Config{
-		DNS:           "1.1.1.1",
+		DNS:           "77.88.8.8",
 		EncryptionKey: "",
 		SocksPort:     "1080",
 		ConferenceID:  "",


### PR DESCRIPTION
- Update internal/protect to force IPv4 and support custom DNS resolvers.
- Add -dns flag support to client mode.
- Change default DNS server to Yandex DNS (77.88.8.8).
- Fix connectivity issues on Android/ARM64 by bypassing broken IPv6 stacks.

AI, but Google or CF dns not working on whitelist.