### PR TITLE
fix: harden secret handling and SOCKS defaults

### DIFF
--- a/internal/provider/jazz/peer.go
+++ b/internal/provider/jazz/peer.go
@@ -77,8 +77,8 @@ func NewPeer(ctx context.Context, roomID, name string, onData func([]byte)) (*Pe
 		if err != nil {
 			return nil, fmt.Errorf("create room: %w", err)
 		}
-		log.Printf("Jazz room created: %s:%s", roomInfo.RoomID, roomInfo.Password)
-		log.Printf("To connect client use: -id \"%s:%s\"", roomInfo.RoomID, roomInfo.Password)
+		log.Printf("Jazz room created: %s", roomInfo.RoomID)
+		log.Printf("Jazz room password generated; share it with the client out-of-band")
 	} else {
 		var password string
 		parts := strings.Split(roomID, ":")

--- a/script/cnc.sh
+++ b/script/cnc.sh
@@ -274,7 +274,7 @@ podman run -d \
     $IMAGE_NAME \
     ./olcrtc -mode cnc -carrier "$CARRIER" -id "$ROOM_ID" -client-id "$CLIENT_ID" -key "$KEY" \
         -link direct -transport "$TRANSPORT" -dns "$DNS" -data data \
-        -socks-host 0.0.0.0 -socks-port "$SOCKS_PORT" "${TRANSPORT_ARGS[@]}"
+        -socks-host 127.0.0.1 -socks-port "$SOCKS_PORT" "${TRANSPORT_ARGS[@]}"
 
 sleep 2
 

--- a/script/docker/olcrtc-entrypoint.sh
+++ b/script/docker/olcrtc-entrypoint.sh
@@ -83,7 +83,7 @@ if [ -z "$key" ]; then
         umask 077
         printf '%s\n' "$key" > "$key_file"
         echo "olcrtc-entrypoint: generated encryption key and saved it to $key_file" >&2
-        echo "olcrtc-entrypoint: OLCRTC_KEY=$key" >&2
+        echo "olcrtc-entrypoint: keep $key_file private; the key is not echoed to logs" >&2
     fi
 fi
 

--- a/script/srv.sh
+++ b/script/srv.sh
@@ -304,8 +304,9 @@ else
     chmod 600 "$KEY_FILE"
     echo ""
     echo "=========================================="
-    echo "NEW ENCRYPTION KEY (saved to $KEY_FILE):"
-    echo "$KEY"
+    echo "NEW ENCRYPTION KEY GENERATED AND SAVED TO:"
+    echo "$KEY_FILE"
+    echo "Keep this file private; the key is not echoed to stdout."
     echo "=========================================="
     echo ""
 fi
@@ -329,7 +330,7 @@ echo "Carrier:        $CARRIER"
 echo "Transport:      $TRANSPORT"
 echo "Room ID:        $ROOM_ID"
 echo "Client ID:      $CLIENT_ID"
-echo "Encryption key: $KEY"
+echo "Encryption key: [hidden] (stored at $KEY_FILE)"
 
 if [ ${#EXTRA_ARGS[@]} -gt 0 ]; then
     echo "SOCKS5 proxy:   $SOCKS_PROXY_ADDR:$SOCKS_PROXY_PORT"
@@ -343,7 +344,7 @@ echo "Stop server:"
 echo "  podman stop $CONTAINER_NAME"
 echo ""
 echo "Client command:"
-echo -n "  ./olcrtc -mode cnc -carrier \"$CARRIER\" -id \"$ROOM_ID\" -client-id \"$CLIENT_ID\" -key \"$KEY\" \\"
+echo -n "  ./olcrtc -mode cnc -carrier \"$CARRIER\" -id \"$ROOM_ID\" -client-id \"$CLIENT_ID\" -key \"<read-from-$KEY_FILE>\" \\"
 echo ""
 echo -n "    -link direct -transport \"$TRANSPORT\" -dns 1.1.1.1:53 -data data \\"
 echo ""
@@ -369,5 +370,5 @@ if [ "$TRANSPORT" = "seichannel" ]; then
     echo ""
 fi
 
-echo "    -socks-host 0.0.0.0 -socks-port 1080"
+echo "    -socks-host 127.0.0.1 -socks-port 1080"
 echo ""


### PR DESCRIPTION
## Summary
- stop echoing generated encryption keys into docker/deploy logs
- keep generated Jazz room password out of normal logs
- switch helper client examples/scripts back to loopback-only SOCKS binding by default

## Why
These changes reduce accidental secret disclosure and avoid shipping an open SOCKS proxy default in helper scripts, without changing the underlying runtime protocol or breaking normal local usage.

## Verification
- `bash -n script/cnc.sh`
- `bash -n script/srv.sh`
- `sh -n script/docker/olcrtc-entrypoint.sh`
