### PR TITLE
feat(server): outbound SOCKS5 proxy auth + fix silent startup error loss

### DIFF
--- a/cmd/olcrtc/main.go
+++ b/cmd/olcrtc/main.go
@@ -63,6 +63,7 @@ type failoverConfig struct {
 func main() {
 	if err := run(); err != nil {
 		logger.Error(err)
+		flushStderrFilter()
 		os.Exit(1)
 	}
 }

--- a/cmd/olcrtc/stderr_filter_unix.go
+++ b/cmd/olcrtc/stderr_filter_unix.go
@@ -11,11 +11,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var ( //nolint:gochecknoglobals // process-wide stderr fd filter
-	stderrFilterOnce   sync.Once
-	stderrPipeWriter   *os.File
-	stderrFilterDone   chan struct{}
-	stderrFilterActive bool
+var (
+	stderrFilterOnce   sync.Once    //nolint:gochecknoglobals // process-wide stderr fd filter
+	stderrPipeWriter   *os.File     //nolint:gochecknoglobals // process-wide stderr fd filter
+	stderrFilterDone   chan struct{} //nolint:gochecknoglobals // process-wide stderr fd filter
+	stderrFilterActive bool         //nolint:gochecknoglobals // process-wide stderr fd filter
 )
 
 func installStderrFilter() {

--- a/cmd/olcrtc/stderr_filter_unix.go
+++ b/cmd/olcrtc/stderr_filter_unix.go
@@ -11,7 +11,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var stderrFilterOnce sync.Once //nolint:gochecknoglobals // process-wide stderr fd filter
+var ( //nolint:gochecknoglobals // process-wide stderr fd filter
+	stderrFilterOnce   sync.Once
+	stderrPipeWriter   *os.File
+	stderrFilterDone   chan struct{}
+	stderrFilterActive bool
+)
 
 func installStderrFilter() {
 	stderrFilterOnce.Do(func() {
@@ -30,11 +35,27 @@ func installStderrFilter() {
 			_ = unix.Close(origFD)
 			return
 		}
-		_ = writer.Close()
+		stderrPipeWriter = writer
+		stderrFilterDone = make(chan struct{})
+		stderrFilterActive = true
 		os.Stderr = os.NewFile(uintptr(unix.Stderr), "/dev/stderr")
 		orig := os.NewFile(uintptr(origFD), "/dev/stderr-original")
-		go copyFilteredStderr(reader, orig)
+		go func() {
+			defer close(stderrFilterDone)
+			copyFilteredStderr(reader, orig)
+		}()
 	})
+}
+
+// flushStderrFilter closes the pipe write ends so the filter goroutine
+// sees EOF and drains any buffered output before the process exits.
+func flushStderrFilter() {
+	if !stderrFilterActive {
+		return
+	}
+	_ = stderrPipeWriter.Close()
+	_ = unix.Close(unix.Stderr)
+	<-stderrFilterDone
 }
 
 func copyFilteredStderr(reader *os.File, out io.Writer) {

--- a/cmd/olcrtc/stderr_filter_windows.go
+++ b/cmd/olcrtc/stderr_filter_windows.go
@@ -3,3 +3,5 @@
 package main
 
 func installStderrFilter() {}
+
+func flushStderrFilter() {}

--- a/internal/app/session/session.go
+++ b/internal/app/session/session.go
@@ -189,6 +189,8 @@ type Config struct {
 	DNSServer             string
 	SOCKSProxyAddr        string
 	SOCKSProxyPort        int
+	SOCKSProxyUser        string
+	SOCKSProxyPass        string
 	Video                 VideoConfig
 	VP8                   VP8Config
 	SEI                   SEIConfig
@@ -652,6 +654,8 @@ func runOnce(
 			DNSServer:        cfg.DNSServer,
 			SOCKSProxyAddr:   cfg.SOCKSProxyAddr,
 			SOCKSProxyPort:   cfg.SOCKSProxyPort,
+			SOCKSProxyUser:   cfg.SOCKSProxyUser,
+			SOCKSProxyPass:   cfg.SOCKSProxyPass,
 			TransportOptions: opts,
 			Engine:           cfg.Engine,
 			URL:              cfg.URL,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,8 @@ type SOCKS struct {
 	Pass      string `yaml:"pass"`
 	ProxyAddr string `yaml:"proxy_addr"`
 	ProxyPort int    `yaml:"proxy_port"`
+	ProxyUser string `yaml:"proxy_user"`
+	ProxyPass string `yaml:"proxy_pass"`
 }
 
 // Engine selects a direct SFU connection when Auth.Provider is "none".
@@ -262,6 +264,8 @@ func Apply(dst session.Config, f File) session.Config {
 	dst.DNSServer = pickString(dst.DNSServer, f.Net.DNS)
 	dst.SOCKSProxyAddr = pickString(dst.SOCKSProxyAddr, f.SOCKS.ProxyAddr)
 	dst.SOCKSProxyPort = pickInt(dst.SOCKSProxyPort, f.SOCKS.ProxyPort)
+	dst.SOCKSProxyUser = pickString(dst.SOCKSProxyUser, f.SOCKS.ProxyUser)
+	dst.SOCKSProxyPass = pickString(dst.SOCKSProxyPass, f.SOCKS.ProxyPass)
 	dst.Video.Width = pickInt(dst.Video.Width, f.Video.Width)
 	dst.Video.Height = pickInt(dst.Video.Height, f.Video.Height)
 	dst.Video.FPS = pickInt(dst.Video.FPS, f.Video.FPS)
@@ -307,6 +311,8 @@ func ApplyProfile(base session.Config, p Profile) session.Config {
 	dst.DNSServer = overlayString(dst.DNSServer, p.Net.DNS)
 	dst.SOCKSProxyAddr = overlayString(dst.SOCKSProxyAddr, p.SOCKS.ProxyAddr)
 	dst.SOCKSProxyPort = overlayInt(dst.SOCKSProxyPort, p.SOCKS.ProxyPort)
+	dst.SOCKSProxyUser = overlayString(dst.SOCKSProxyUser, p.SOCKS.ProxyUser)
+	dst.SOCKSProxyPass = overlayString(dst.SOCKSProxyPass, p.SOCKS.ProxyPass)
 	dst.Video.Width = overlayInt(dst.Video.Width, p.Video.Width)
 	dst.Video.Height = overlayInt(dst.Video.Height, p.Video.Height)
 	dst.Video.FPS = overlayInt(dst.Video.FPS, p.Video.FPS)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -77,6 +77,8 @@ type Server struct {
 	resolver       *net.Resolver
 	socksProxyAddr string
 	socksProxyPort int
+	socksProxyUser string
+	socksProxyPass string
 	liveness       control.Config
 	health         *runtime.HealthTracker
 	done           chan struct{}
@@ -110,6 +112,8 @@ type Config struct {
 	DNSServer        string
 	SOCKSProxyAddr   string
 	SOCKSProxyPort   int
+	SOCKSProxyUser   string
+	SOCKSProxyPass   string
 	TransportOptions transport.Options
 	Engine           string
 	URL              string
@@ -166,6 +170,8 @@ func Run(ctx context.Context, cfg Config) error {
 		dnsServer:      cfg.DNSServer,
 		socksProxyAddr: cfg.SOCKSProxyAddr,
 		socksProxyPort: cfg.SOCKSProxyPort,
+		socksProxyUser: cfg.SOCKSProxyUser,
+		socksProxyPass: cfg.SOCKSProxyPass,
 		liveness:       cfg.Liveness,
 		health:         runtime.NewHealthTracker(cfg.OnHealth),
 		peerSessions:   make(map[string]*peerSession),
@@ -914,15 +920,55 @@ func (s *Server) dial(req ConnectRequest) (net.Conn, error) {
 }
 
 func (s *Server) socks5Connect(conn net.Conn, targetAddr string, targetPort int) error {
-	if _, err := conn.Write([]byte{5, 1, 0}); err != nil {
-		return fmt.Errorf("failed to write socks5 auth: %w", err)
+	if s.socksProxyUser != "" {
+		// Offer username/password auth (RFC 1929) only.
+		if _, err := conn.Write([]byte{5, 1, 2}); err != nil {
+			return fmt.Errorf("failed to write socks5 auth: %w", err)
+		}
+	} else {
+		// No authentication.
+		if _, err := conn.Write([]byte{5, 1, 0}); err != nil {
+			return fmt.Errorf("failed to write socks5 auth: %w", err)
+		}
 	}
 
 	resp := make([]byte, 2)
 	if _, err := io.ReadFull(conn, resp); err != nil {
 		return fmt.Errorf("failed to read socks5 auth resp: %w", err)
 	}
-	if resp[0] != 5 || resp[1] != 0 {
+	if resp[0] != 5 {
+		return ErrSocks5AuthFailed
+	}
+	switch resp[1] {
+	case 0: // no auth accepted
+		if s.socksProxyUser != "" {
+			return ErrSocks5AuthFailed
+		}
+	case 2: // username/password
+		user := s.socksProxyUser
+		pass := s.socksProxyPass
+		if len(user) > 255 {
+			user = user[:255]
+		}
+		if len(pass) > 255 {
+			pass = pass[:255]
+		}
+		authMsg := make([]byte, 0, 3+len(user)+len(pass))
+		authMsg = append(authMsg, 1, byte(len(user)))
+		authMsg = append(authMsg, []byte(user)...)
+		authMsg = append(authMsg, byte(len(pass)))
+		authMsg = append(authMsg, []byte(pass)...)
+		if _, err := conn.Write(authMsg); err != nil {
+			return fmt.Errorf("failed to write socks5 credentials: %w", err)
+		}
+		authResp := make([]byte, 2)
+		if _, err := io.ReadFull(conn, authResp); err != nil {
+			return fmt.Errorf("failed to read socks5 credentials resp: %w", err)
+		}
+		if authResp[1] != 0 {
+			return ErrSocks5AuthFailed
+		}
+	default:
 		return ErrSocks5AuthFailed
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -920,6 +920,37 @@ func (s *Server) dial(req ConnectRequest) (net.Conn, error) {
 }
 
 func (s *Server) socks5Connect(conn net.Conn, targetAddr string, targetPort int) error {
+	if err := s.socks5Authenticate(conn); err != nil {
+		return err
+	}
+
+	addrLen := len(targetAddr)
+	if addrLen > 255 {
+		addrLen = 255
+		targetAddr = targetAddr[:255]
+	}
+
+	req := make([]byte, 0, 7+addrLen)
+	req = append(req, 5, 1, 0, 3, byte(addrLen))
+	req = append(req, []byte(targetAddr)...)
+	req = append(req, byte(targetPort>>8), byte(targetPort)) //nolint:gosec,lll // G115: bounded conversion verified by surrounding logic
+
+	if _, err := conn.Write(req); err != nil {
+		return fmt.Errorf("failed to write socks5 connect req: %w", err)
+	}
+
+	resp := make([]byte, 10)
+	if _, err := io.ReadFull(conn, resp); err != nil {
+		return fmt.Errorf("failed to read socks5 connect resp: %w", err)
+	}
+	if resp[0] != 5 || resp[1] != 0 {
+		return fmt.Errorf("%w: %d", ErrSocks5ConnectFailed, resp[1])
+	}
+
+	return nil
+}
+
+func (s *Server) socks5Authenticate(conn net.Conn) error {
 	if s.socksProxyUser != "" {
 		// Offer username/password auth (RFC 1929) only.
 		if _, err := conn.Write([]byte{5, 1, 2}); err != nil {
@@ -945,55 +976,36 @@ func (s *Server) socks5Connect(conn net.Conn, targetAddr string, targetPort int)
 			return ErrSocks5AuthFailed
 		}
 	case 2: // username/password
-		user := s.socksProxyUser
-		pass := s.socksProxyPass
-		if len(user) > 255 {
-			user = user[:255]
-		}
-		if len(pass) > 255 {
-			pass = pass[:255]
-		}
-		authMsg := make([]byte, 0, 3+len(user)+len(pass))
-		authMsg = append(authMsg, 1, byte(len(user)))
-		authMsg = append(authMsg, []byte(user)...)
-		authMsg = append(authMsg, byte(len(pass)))
-		authMsg = append(authMsg, []byte(pass)...)
-		if _, err := conn.Write(authMsg); err != nil {
-			return fmt.Errorf("failed to write socks5 credentials: %w", err)
-		}
-		authResp := make([]byte, 2)
-		if _, err := io.ReadFull(conn, authResp); err != nil {
-			return fmt.Errorf("failed to read socks5 credentials resp: %w", err)
-		}
-		if authResp[1] != 0 {
-			return ErrSocks5AuthFailed
-		}
+		return s.socks5SendCredentials(conn)
 	default:
 		return ErrSocks5AuthFailed
 	}
+	return nil
+}
 
-	addrLen := len(targetAddr)
-	if addrLen > 255 {
-		addrLen = 255
-		targetAddr = targetAddr[:255]
+func (s *Server) socks5SendCredentials(conn net.Conn) error {
+	user := s.socksProxyUser
+	pass := s.socksProxyPass
+	if len(user) > 255 {
+		user = user[:255]
 	}
-
-	req := make([]byte, 0, 7+addrLen)
-	req = append(req, 5, 1, 0, 3, byte(addrLen))
-	req = append(req, []byte(targetAddr)...)
-	req = append(req, byte(targetPort>>8), byte(targetPort)) //nolint:gosec,lll // G115: bounded conversion verified by surrounding logic
-
-	if _, err := conn.Write(req); err != nil {
-		return fmt.Errorf("failed to write socks5 connect req: %w", err)
+	if len(pass) > 255 {
+		pass = pass[:255]
 	}
-
-	resp = make([]byte, 10)
-	if _, err := io.ReadFull(conn, resp); err != nil {
-		return fmt.Errorf("failed to read socks5 connect resp: %w", err)
+	authMsg := make([]byte, 0, 3+len(user)+len(pass))
+	authMsg = append(authMsg, 1, byte(len(user))) //nolint:gosec // G115: len clamped to ≤255 above
+	authMsg = append(authMsg, []byte(user)...)
+	authMsg = append(authMsg, byte(len(pass))) //nolint:gosec // G115: len clamped to ≤255 above
+	authMsg = append(authMsg, []byte(pass)...)
+	if _, err := conn.Write(authMsg); err != nil {
+		return fmt.Errorf("failed to write socks5 credentials: %w", err)
 	}
-	if resp[0] != 5 || resp[1] != 0 {
-		return fmt.Errorf("%w: %d", ErrSocks5ConnectFailed, resp[1])
+	authResp := make([]byte, 2)
+	if _, err := io.ReadFull(conn, authResp); err != nil {
+		return fmt.Errorf("failed to read socks5 credentials resp: %w", err)
 	}
-
+	if authResp[1] != 0 {
+		return ErrSocks5AuthFailed
+	}
 	return nil
 }

--- a/pkg/olcrtc/tunnel/tunnel.go
+++ b/pkg/olcrtc/tunnel/tunnel.go
@@ -85,6 +85,8 @@ type Config struct {
 	DNSServer      string // resolver used for target dials, e.g. "8.8.8.8:53"
 	SOCKSProxyAddr string // optional outbound SOCKS5 proxy host
 	SOCKSProxyPort int    // optional outbound SOCKS5 proxy port
+	SOCKSProxyUser string // optional username for SOCKS5 proxy auth (RFC 1929)
+	SOCKSProxyPass string // optional password for SOCKS5 proxy auth (RFC 1929)
 
 	// --- transport tuning ---
 	// TransportOptions carries transport-specific tuning. Use the Options
@@ -128,6 +130,8 @@ func (s *Server) Run(ctx context.Context) error {
 		DNSServer:        s.cfg.DNSServer,
 		SOCKSProxyAddr:   s.cfg.SOCKSProxyAddr,
 		SOCKSProxyPort:   s.cfg.SOCKSProxyPort,
+		SOCKSProxyUser:   s.cfg.SOCKSProxyUser,
+		SOCKSProxyPass:   s.cfg.SOCKSProxyPass,
 		TransportOptions: s.cfg.TransportOptions,
 		AuthHook:         s.cfg.AuthHook,
 		OnSessionOpen:    s.cfg.OnSessionOpen,


### PR DESCRIPTION
## Поддержка логина/пароля для исходящего SOCKS5-прокси

Сервер мог использовать SOCKS5-прокси для исходящих соединений, но без
аутентификации — отправлял метод `no-auth (0x00)`, и прокси с обязательным
логином/паролем отклонял соединение.

Добавлена поддержка RFC 1929: если в конфиге указаны `proxy_user`/`proxy_pass`,
сервер предлагает метод `username/password (0x02)` и выполняет handshake
аутентификации. Поля прокинуты через всю цепочку: `config → session → server`.

```yaml
socks:
  proxy_addr: "1.2.3.4"
  proxy_port: 1080
  proxy_user: "user"
  proxy_pass: "pass"
```

## Фикс: сообщение об ошибке пропадало при падении на старте

При ошибке запуска горутина-фильтр stderr убивалась `os.Exit(1)` раньше, чем
успевала переслать сообщение в настоящий stderr. Добавлена `flushStderrFilter()`,
которая закрывает pipe и ждёт завершения горутины перед выходом.

**До:** запуск с невалидным конфигом — никакого вывода, код выхода 1.  
**После:** ошибка печатается как ожидается.
