### PR TITLE
fix(jitsi): break out of rtcpKeepalive on persistent write errors

### DIFF
--- a/internal/engine/jitsi/jitsi.go
+++ b/internal/engine/jitsi/jitsi.go
@@ -572,9 +572,11 @@ type negotiator interface {
 func (s *Session) rtcpKeepalive(pc *webrtc.PeerConnection) {
 	defer s.wg.Done()
 	const interval = 5 * time.Second
+	const maxErrors = 3
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	pkts := []rtcp.Packet{&rtcp.ReceiverReport{}}
+	errCount := 0
 	for {
 		select {
 		case <-s.done:
@@ -584,7 +586,15 @@ func (s *Session) rtcpKeepalive(pc *webrtc.PeerConnection) {
 				if s.closed.Load() {
 					return
 				}
-				logger.Debugf("jitsi: rtcp keepalive write: %v", err)
+				errCount++
+				logger.Debugf("jitsi: rtcp keepalive write (%d/%d): %v", errCount, maxErrors, err)
+				if errCount >= maxErrors {
+					logger.Warnf("jitsi: rtcp keepalive giving up after %d errors", maxErrors)
+					s.requestReconnect("rtcp keepalive dead")
+					return
+				}
+			} else {
+				errCount = 0
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- `rtcpKeepalive` goroutine spins forever when `WriteRTCP` fails on a dead PeerConnection that hasn't been closed yet (bridge disconnected, reconnect pending). It logs `rtcp keepalive write: io: read/write on closed pipe` every 5 seconds indefinitely — the instance is functionally dead but systemd sees it as alive.
- Added an error counter: after 3 consecutive `WriteRTCP` failures, call `requestReconnect("rtcp keepalive dead")` and exit the loop. Counter resets on any successful write.

## Reproduction

1. Start an `olcrtc` server instance with `jitsi` + `datachannel`
2. Connect a client and pass some traffic
3. Disconnect the client and wait ~20-60s for the Jitsi single-participant-timeout to kill the bridge
4. Observe journal: `rtcp keepalive write: io: read/write on closed pipe` repeats every 5s forever
5. The instance never recovers — new clients cannot connect

## After fix

The loop exits after 3 errors, `requestReconnect` is called, the supervisor re-establishes the bridge, and the instance is ready for new clients.

## Test plan

- [x] Deployed on production (3 instances, jitsi+datachannel) — confirmed no more keepalive wedge after client disconnect
- [x] Verified reconnect triggers correctly after consecutive write failures
- [x] Verified multi-client connectivity works after reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)