### PR TITLE
fix(jitsi): re-allocate Jicofo focus on reconnect (non-blocking)

### DIFF
--- a/internal/engine/jitsi/jitsi.go
+++ b/internal/engine/jitsi/jitsi.go
@@ -1329,19 +1329,37 @@ func (s *Session) reconnect(ctx context.Context) error {
 	s.resetPeerEpochs()
 	s.drainSendQueue()
 
-	jSess := s.jSess.Load()
-	if jSess == nil {
-		return s.reconnectFull(ctx)
+	// Re-establish the XMPP/MUC session from scratch rather than reusing the
+	// lightweight jSess.Rejoin (leave+join) path. Rejoin skips the Jicofo
+	// focus-allocation IQ, and Jitsi gates the MUC on focus: once the server
+	// is left alone in the room, Jicofo idle-terminates the conference
+	// (session-terminate <expired/>) and tears down the room, after which a
+	// bare presence is rejected with <presence type='error'><not-allowed/>.
+	// The library's JoinMUC then matches a stale status-110 still buffered in
+	// its stanza channel and falsely reports success, so we wait forever for a
+	// session-initiate that never comes while actually being outside the room.
+	//
+	// j.JoinMUC re-runs dial -> focus allocation -> MUC join in the correct
+	// order (focus first, so Jicofo recreates the room), exactly like the
+	// initial Connect, but WITHOUT blocking on session-initiate — preserving
+	// the non-blocking reconnect contract. We wait for the fresh
+	// session-initiate separately via WaitJingleReinitiate once a peer rejoins.
+	if old := s.jSess.Swap(nil); old != nil {
+		_ = old.Close()
 	}
 
-	// Rejoin MUC (leave + join) without waiting for session-initiate.
-	// This resets Jicofo's state for our participant so it will send
-	// a fresh session-initiate when another peer arrives.
 	logger.Infof("jitsi: rejoin %s/%s (non-blocking) ...", s.host, s.room)
-	if err := jSess.Rejoin(ctx, s.name); err != nil {
+	jSess, err := j.JoinMUC(ctx, j.Config{
+		Host:  s.host,
+		Room:  s.room,
+		Nick:  s.name,
+		Debug: logger.IsVerbose(),
+	})
+	if err != nil {
 		logger.Warnf("jitsi: rejoin failed: %v - full reconnect", err)
 		return s.reconnectFull(ctx)
 	}
+	s.jSess.Store(jSess)
 
 	// Wait for Jicofo to send session-initiate (when a peer joins the room).
 	logger.Infof("jitsi: waiting for session-initiate in %s/%s ...", s.host, s.room)


### PR DESCRIPTION
# fix(jitsi): переаллокация Jicofo focus при реконнекте

## Симптом

После успешного цикла «подключение → отключение» сервер через 1–2 минуты перестаёт принимать клиента: новый клиент не может подключиться. В логах сервера это выглядит так:

```
[pc] INFO: Closing PeerConnection from DTLS CloseNotify
jitsi reconnect requested: jitsi bridge closed
jitsi: rejoin meet1.arbitr.ru/<room> (non-blocking) ...
jitsi: waiting for session-initiate in meet1.arbitr.ru/<room> ...
jitsi: rtcp keepalive giving up after 3 errors
<тишина — session-initiate не приходит никогда>
```

Реконнект навсегда зависает на `waiting for session-initiate`.

## Первопричина

Разрыв инициирует **Jicofo, а не клиент**. Когда клиент уходит, сервер остаётся в комнате один, и Jicofo по idle-таймауту гасит конференцию: `session-terminate … <expired/> "Idle session timeout"`. При этом комната и фокус-аллокация на стороне Jicofo/Prosody сносятся.

Дальнейший реконнект шёл по «лёгкому» пути `jSess.Rejoin` (leave + join), и здесь есть две связанные проблемы:

1. **`Rejoin` не переаллоцирует focus.** Сравните два пути в библиотеке `j`:
   - Полный `Join`: `dial → DiscoverServices → AllocateFocus → JoinMUC → WaitJingle`.
   - `Rejoin`: только `LeaveMUCWait → JoinMUC`. **`AllocateFocus` отсутствует.**

   `AllocateFocus` — это IQ `<conference … xmlns="http://jitsi.org/protocol/focus"/>` к `focus.<domain>`, которым клиент приглашает Jicofo управлять комнатой и пересоздаёт её. Без него Jicofo в комнату не возвращается → `session-initiate` присылать некому.

2. **Порядок: focus обязан идти ДО входа в MUC.** Jitsi гейтит MUC на наличие focus: после сноса комнаты голый presence отклоняется Prosody как `<presence type='error'><not-allowed/>`. А `Conn.JoinMUC` в библиотеке ждёт **только** `status code="110"` и не распознаёт presence-ошибку — он матчит устаревший `110`, оставшийся в буфере `c.stanzas`, и **ложно рапортует успех**. В итоге движок считает, что вошёл в комнату, и уходит в бесконечное ожидание `session-initiate`, фактически находясь вне комнаты.

`rtcp keepalive giving up` в логах — это просто догорающая goroutine старого PeerConnection (он уже закрыт в `teardownPC`), на саму проблему она не влияет.

## Исправление

В `Session.reconnect()` лёгкий `jSess.Rejoin` заменён на пересоздание сессии через **`j.JoinMUC`**:

```go
if old := s.jSess.Swap(nil); old != nil {
    _ = old.Close()
}

jSess, err := j.JoinMUC(ctx, j.Config{
    Host: s.host, Room: s.room, Nick: s.name, Debug: logger.IsVerbose(),
})
if err != nil {
    return s.reconnectFull(ctx)
}
s.jSess.Store(jSess)

if _, err := jSess.WaitJingleReinitiate(ctx); err != nil {
    return s.reconnectFull(ctx)
}
// ... reinitiateBridge → recvLoop → onReconnect (как раньше)
```

Почему именно `j.JoinMUC`:

- делает `dial → AllocateFocus → JoinMUC` в **правильном порядке** (focus первым, Jicofo пересоздаёт комнату) — ровно как начальный `Connect`, который и так использует `j.JoinMUC`;
- в отличие от `j.Join`, **не блокируется** на `session-initiate` — non-blocking-контракт реконнекта сохранён; свежий `session-initiate` ждём отдельно через `WaitJingleReinitiate`, когда клиент вернётся в комнату;
- свежая сессия даёт чистый bridge. Это важно: переиспользовать `Rejoin` со старой сессией нельзя — внутреннее поле `s.bridge` сбрасывают в nil только `Rejoin`/`Close`, а `OpenBridge`/`WaitBridgeSCTP` при `s.bridge != nil` делают ранний возврат и переиспользовали бы мёртвый bridge.

Фикс лечит обе проблемы — и отсутствие focus, и `not-allowed`. Изменение полностью на стороне olcrtc, библиотека `j` не трогается (используются только её экспортированные API).

## Проверка

- Локально: `go build ./...`, `go vet`, `go test ./internal/engine/jitsi/...` — зелёные.
- На живом деплое поймано **два полных цикла реконнекта подряд**, оба успешны:

```
bridge closed → reconnect requested
rejoin (non-blocking) ... → waiting for session-initiate ...
bridge open sctp (endpoints=[…]) → reconnected (reinitiate) → session opened
```

Задержка между `rejoin` и `reconnected` — это неблокирующее ожидание возвращения клиента; как только он возвращается, реконнект завершается за <1с. Раньше на этом месте была бесконечная тишина.

## Связь с PR #85

PR #85 (`fix(jitsi): make Connect non-blocking`) сделал неблокирующим **первичный** `Connect()`, переключив его с `j.Join` на `j.JoinMUC` + асинхронный `waitForJingle`. Но путь **реконнекта** (`Session.reconnect()`) он не затрагивал — там остался лёгкий `jSess.Rejoin`. Этот PR распространяет ту же идею (`j.JoinMUC`) на `reconnect()`, чем и устраняет зависание после idle-terminate Jicofo.
