### PR TITLE
feat(server): log live peer count and connect/disconnect events

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -66,6 +68,8 @@ type Server struct {
 	controlStop    context.CancelFunc
 	sessMu         sync.RWMutex
 	peerSessions   map[string]*peerSession
+	peersMu        sync.Mutex
+	peerStats      map[string]peerStat
 	reinstallMu    sync.Mutex
 	wg             sync.WaitGroup
 	authHook       handshake.AuthFunc
@@ -84,6 +88,13 @@ type Server struct {
 	health         *runtime.HealthTracker
 	done           chan struct{}
 	doneOnce       sync.Once
+}
+
+// peerStat holds the per-session info needed to report the live peer count
+// and a disconnect summary.
+type peerStat struct {
+	deviceID string
+	openedAt time.Time
 }
 
 type peerSession struct {
@@ -176,6 +187,7 @@ func Run(ctx context.Context, cfg Config) error {
 		liveness:       cfg.Liveness,
 		health:         runtime.NewHealthTracker(cfg.OnHealth),
 		peerSessions:   make(map[string]*peerSession),
+		peerStats:      make(map[string]peerStat),
 		done:           make(chan struct{}),
 	}
 	s.setupResolver()
@@ -283,6 +295,7 @@ func (s *Server) bringUpLink(
 		return fmt.Errorf("failed to connect link: %w", err)
 	}
 	logger.Infof("Link connected")
+	s.logPeersLine()
 
 	s.wg.Add(1)
 	go func() {
@@ -371,6 +384,7 @@ func (s *Server) reinstallSession(dead *smux.Session) {
 	}
 	if oldSID != "" {
 		s.onClose(oldSID, "reconnect")
+		s.trackPeerClose(oldSID, "reconnect")
 	}
 }
 
@@ -403,6 +417,7 @@ func (s *Server) closeSession() {
 	}
 	if oldSID != "" {
 		s.onClose(oldSID, "closed")
+		s.trackPeerClose(oldSID, "closed")
 	}
 	for _, ps := range peers {
 		s.closePeerSession(ps, "closed")
@@ -435,7 +450,54 @@ func (s *Server) closePeerSession(ps *peerSession, reason string) {
 	}
 	if ps.sessionID != "" {
 		s.onClose(ps.sessionID, reason)
+		s.trackPeerClose(ps.sessionID, reason)
 	}
+}
+
+// trackPeerOpen records a newly opened session and logs the live peer summary.
+func (s *Server) trackPeerOpen(sessionID, deviceID string) {
+	s.peersMu.Lock()
+	s.peerStats[sessionID] = peerStat{deviceID: deviceID, openedAt: time.Now()}
+	line := s.peersLineLocked()
+	s.peersMu.Unlock()
+	logger.Infof("peer connected: device=%s session=%s", deviceID, sessionID)
+	logger.Infof("%s", line)
+}
+
+// trackPeerClose drops a closed session and logs a disconnect summary plus the
+// live peer summary.
+func (s *Server) trackPeerClose(sessionID, reason string) {
+	s.peersMu.Lock()
+	st, ok := s.peerStats[sessionID]
+	if !ok {
+		s.peersMu.Unlock()
+		return // session was never tracked (or already removed) - avoid double count
+	}
+	delete(s.peerStats, sessionID)
+	line := s.peersLineLocked()
+	s.peersMu.Unlock()
+	logger.Infof("peer disconnected: device=%s session=%s reason=%s duration=%s",
+		st.deviceID, sessionID, reason, time.Since(st.openedAt).Round(time.Second))
+	logger.Infof("%s", line)
+}
+
+// peersLineLocked builds the "Current peers count: N, Devices: [...]" summary
+// line from the live sessions. The caller must hold peersMu.
+func (s *Server) peersLineLocked() string {
+	devices := make([]string, 0, len(s.peerStats))
+	for _, st := range s.peerStats {
+		devices = append(devices, st.deviceID)
+	}
+	sort.Strings(devices)
+	return fmt.Sprintf("Current peers count: %d, Devices: [%s]", len(s.peerStats), strings.Join(devices, ", "))
+}
+
+// logPeersLine logs the current peer summary line (count + device list).
+func (s *Server) logPeersLine() {
+	s.peersMu.Lock()
+	line := s.peersLineLocked()
+	s.peersMu.Unlock()
+	logger.Infof("%s", line)
 }
 
 func notifyControlClose(stream *smux.Stream) {
@@ -625,6 +687,7 @@ func (s *Server) acceptHandshake(ctx context.Context, sess *smux.Session) bool {
 		s.sessMu.Unlock()
 		s.recordSession(sid)
 		s.onOpen(sid, hello.DeviceID, hello.Claims)
+		s.trackPeerOpen(sid, hello.DeviceID)
 		logger.Infof("session %s opened (device=%s)", sid, hello.DeviceID)
 		s.startControlLoop(ctx, sess, stream)
 		return true
@@ -685,6 +748,7 @@ func (s *Server) acceptPeerHandshake(ps *peerSession) bool {
 		ps.sessionID = sid
 		s.recordSession(sid)
 		s.onOpen(sid, hello.DeviceID, hello.Claims)
+		s.trackPeerOpen(sid, hello.DeviceID)
 		logger.Infof("session %s opened (device=%s peer=%s)", sid, hello.DeviceID, ps.peerID)
 		s.startPeerControlLoop(ps, stream)
 		return true


### PR DESCRIPTION
## Что меняет PR

Сервер (`mode: srv`) теперь печатает в лог текущее число подключённых клиентов и
события их подключения/отключения. После поднятия линка и на каждый
connect/disconnect выводится строка `Current peers count: N, Devices: [<device-id>, ...]`,
плюс компактные `peer connected: device=… session=…` и
`peer disconnected: device=… session=… reason=… duration=…`. Это даёт
оператору/панели живую видимость числа клиентов на инстансе. Изменение чисто
аддитивное (только логирование): поведение тоннеля, wire-протокол и формат
конфига не затронуты.

## Связанные issue

нет

## Тип изменения

- [ ] fix
- [x] feat - новая функциональность
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] build / ci
- [ ] chore
- [ ] BREAKING CHANGE

## Область

- [ ] auth
- [ ] transport / channel
- [ ] mux / control / liveness / lifecycle
- [ ] session / app
- [ ] config / CLI / URI / sub
- [ ] mobile
- [ ] CI / mage
- [ ] docs / examples
- [x] другое: `internal/server` — серверное логирование счётчика подключённых

## Как тестировалось

- Provider: carrier-agnostic (логирование не зависит от провайдера; гонял на jitsi)
- Transport: vp8channel
- ОС: linux + windows
- Сценарий: поднять `srv`, подключить `cnc`, посмотреть лог сервера; затем отключить `cnc`.

```text
# before: таких строк в логе нет

# after:
Link connected
Current peers count: 0, Devices: []
peer connected: device=<deviceA> session=<uuid1>
Current peers count: 1, Devices: [<deviceA>]
peer connected: device=<deviceB> session=<uuid2>
Current peers count: 2, Devices: [<deviceA>, <deviceB>]
peer disconnected: device=<deviceB> session=<uuid2> reason=closed duration=1m0s
Current peers count: 1, Devices: [<deviceA>]