### PR TITLE
fix: resolve connection failures in jitsi and vp8channel transports

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -224,6 +224,12 @@ func (c *Client) bringUpLink(
 		return fmt.Errorf("failed to connect link: %w", err)
 	}
 
+	if waiter, ok := ln.(transport.PeerReadyTransport); ok {
+		if err := waiter.WaitForPeer(ctx); err != nil {
+			return fmt.Errorf("wait for peer: %w", err)
+		}
+	}
+
 	c.conn = muxconn.New(ln, c.cipher)
 	c.controlConn = muxconn.NewControl(ln, c.cipher)
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -224,34 +224,20 @@ func (c *Client) bringUpLink(
 		return fmt.Errorf("failed to connect link: %w", err)
 	}
 
-	if waiter, ok := ln.(transport.PeerReadyTransport); ok {
-		if err := waiter.WaitForPeer(ctx); err != nil {
-			return fmt.Errorf("wait for peer: %w", err)
-		}
+	if err := waitForPeer(ctx, ln); err != nil {
+		return err
 	}
 
 	c.conn = muxconn.New(ln, c.cipher)
 	c.controlConn = muxconn.NewControl(ln, c.cipher)
 
-	sess, err := smux.Client(c.conn, smuxConfig(linkMaxPayload(ln)))
+	sess, controlSess, err := buildSmuxClient(ln, c.conn, c.controlConn)
 	if err != nil {
-		return fmt.Errorf("smux client: %w", err)
-	}
-
-	// If the transport has an isolated control plane, open the handshake/
-	// control smux session over it instead of the bulk data session.
-	var controlSess *smux.Session
-	if c.controlConn != nil {
-		var cerr error
-		controlSess, cerr = smux.Client(c.controlConn, controlSmuxConfig(linkMaxPayload(ln)))
-		if cerr != nil {
-			_ = sess.Close()
-			_ = c.conn.Close()
+		_ = c.conn.Close()
+		if c.controlConn != nil {
 			_ = c.controlConn.Close()
-			return fmt.Errorf("control smux client: %w", cerr)
 		}
-	} else {
-		controlSess = sess
+		return err
 	}
 
 	control, sid, err := openControlStream(ctx, controlSess, c.deviceID, c.claims)
@@ -279,6 +265,56 @@ func (c *Client) bringUpLink(
 
 	go ln.WatchConnection(ctx)
 	return nil
+}
+
+// peerWaitTimeout bounds how long bringUpLink/tryReopenSession will block
+// waiting for the remote peer to appear before giving up. Without a bound a
+// missing peer (server offline, wrong room, never joins) would hang the
+// caller indefinitely — before the SOCKS listener is even created — instead
+// of surfacing a failure. We reuse the handshake timeout so a missing peer
+// fails on the same ~15s budget as a wedged handshake would.
+const peerWaitTimeout = handshake.DefaultTimeout
+
+// waitForPeer blocks until the transport reports a remote peer is ready, the
+// peer-wait deadline elapses, or ctx is cancelled. Transports that don't
+// implement PeerReadyTransport return immediately.
+func waitForPeer(ctx context.Context, ln transport.Transport) error {
+	waiter, ok := ln.(transport.PeerReadyTransport)
+	if !ok {
+		return nil
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, peerWaitTimeout)
+	defer cancel()
+	if err := waiter.WaitForPeer(waitCtx); err != nil {
+		return fmt.Errorf("wait for peer: %w", err)
+	}
+	return nil
+}
+
+// buildSmuxClient creates the bulk-data smux session over conn and, when the
+// transport exposes an isolated control plane (controlConn != nil), a separate
+// smux session over controlConn for handshake/control traffic. When there is
+// no control plane the bulk session doubles as the control session. On error
+// any session opened here is closed; the caller owns conn/controlConn.
+func buildSmuxClient(
+	ln transport.Transport,
+	conn, controlConn *muxconn.Conn,
+) (*smux.Session, *smux.Session, error) {
+	sess, err := smux.Client(conn, smuxConfig(linkMaxPayload(ln)))
+	if err != nil {
+		return nil, nil, fmt.Errorf("smux client: %w", err)
+	}
+	if controlConn == nil {
+		return sess, sess, nil
+	}
+	// Separate smux session for the control stream only: small buffers, no
+	// smux keepalive (our own control.Run ping/pong handles liveness).
+	controlSess, err := smux.Client(controlConn, controlSmuxConfig(linkMaxPayload(ln)))
+	if err != nil {
+		_ = sess.Close()
+		return nil, nil, fmt.Errorf("control smux client: %w", err)
+	}
+	return sess, controlSess, nil
 }
 
 // openControlStream opens stream #1 on sess and performs the handshake.
@@ -516,31 +552,25 @@ func (c *Client) tryReopenSession(
 		_ = oldCtrl.Close()
 	}
 
-	// When we have a dedicated control conn, open the handshake/control smux
-	// session over it. Otherwise fall back to the data conn (legacy transports).
-	controlSmuxConn := conn
-	if controlConn != nil {
-		controlSmuxConn = controlConn
-	}
-
-	sess, err := smux.Client(conn, smuxConfig(linkMaxPayload(c.ln)))
+	sess, controlSess, err := buildSmuxClient(c.ln, conn, controlConn)
 	if err != nil {
 		logger.Warnf("smux re-init failed (attempt %d): %v", attempt, err)
 		return false
 	}
 
-	var controlSess *smux.Session
-	if controlConn != nil {
-		// Separate smux session for the control stream only. We use a minimal
-		// config: small buffers, no keepalive (liveness is our own ping/pong).
-		controlSess, err = smux.Client(controlSmuxConn, controlSmuxConfig(linkMaxPayload(c.ln)))
-		if err != nil {
-			logger.Warnf("control smux re-init failed (attempt %d): %v", attempt, err)
-			_ = sess.Close()
-			return false
+	// Wait for the peer to re-announce before opening the control stream.
+	// resetLinkPeer cleared the peer epoch on reconnect, so without this the
+	// client's first SYN can race ahead of the server's bridge being open
+	// again — the same handshake-ordering race WaitForPeer guards against on
+	// the initial connect. The retry/backoff loop would eventually recover,
+	// but only after a full handshake timeout per attempt.
+	if err := waitForPeer(ctx, c.ln); err != nil {
+		logger.Warnf("wait for peer on reconnect failed (attempt %d): %v", attempt, err)
+		_ = sess.Close()
+		if controlSess != sess {
+			_ = controlSess.Close()
 		}
-	} else {
-		controlSess = sess
+		return false
 	}
 
 	ctrlStream, sid, err := openControlStreamTimeout(ctx, controlSess, c.deviceID, c.claims, handshake.DefaultTimeout)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -98,6 +98,13 @@ type PeerSession interface {
 	SendTo(peerID string, data []byte) error
 }
 
+// PeerReadySession is implemented by engines that can signal when a remote
+// peer has appeared in the shared room. WaitForPeer blocks until the first
+// epoch frame from a remote participant is received, or ctx is cancelled.
+type PeerReadySession interface {
+	WaitForPeer(ctx context.Context) error
+}
+
 // VideoTrackCapable is implemented by engines that can exchange video tracks.
 type VideoTrackCapable interface {
 	AddVideoTrack(track webrtc.TrackLocal) error

--- a/internal/engine/jitsi/jitsi.go
+++ b/internal/engine/jitsi/jitsi.go
@@ -1831,6 +1831,23 @@ func (s *Session) resetPeerEpochs() {
 	s.peerEpochMu.Unlock()
 }
 
+// WaitForPeer blocks until at least one remote participant has sent an epoch
+// frame (confirming their bridge is open), or ctx is cancelled.
+// Implements engine.PeerReadySession.
+func (s *Session) WaitForPeer(ctx context.Context) error {
+	const pollInterval = 50 * time.Millisecond
+	for {
+		if s.peerEpoch.Load() != 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
 // CanSend reports whether the session is ready to accept new data.
 func (s *Session) CanSend() bool {
 	if s.closed.Load() {

--- a/internal/engine/jitsi/jitsi.go
+++ b/internal/engine/jitsi/jitsi.go
@@ -64,6 +64,10 @@ const (
 	// periodic XMPP ping IQ resets that idle timer end-to-end and works for
 	// the WebSocket transport too.
 	xmppKeepaliveInterval = 25 * time.Second
+	// xmppKeepaliveTimeout is the maximum time to wait for a pong reply.
+	// A half-open TCP connection lets Send() succeed while replies never
+	// arrive; waiting for the IQ result detects this and triggers reconnect.
+	xmppKeepaliveTimeout = 15 * time.Second
 	reconnectJoinTimeout  = 30 * time.Second
 )
 
@@ -842,11 +846,11 @@ func (s *Session) xmppKeepalive() {
 				`<iq type="get" to="%s" id="%s" xmlns="jabber:client"><ping xmlns="urn:xmpp:ping"/></iq>`,
 				conn.Host(), id,
 			)
-			if err := conn.Send(ping); err != nil {
+			if _, err := conn.SendIQWait(ping, id, xmppKeepaliveTimeout); err != nil {
 				if s.closed.Load() {
 					return
 				}
-				logger.Debugf("jitsi: xmpp keepalive send: %v", err)
+				logger.Debugf("jitsi: xmpp keepalive: %v", err)
 				// Avoid spamming the supervisor with identical
 				// requests during the reconnect; once a request
 				// is enqueued the channel is buffered to depth 1,
@@ -1090,6 +1094,7 @@ func (s *Session) sendLoop() {
 			if !ok {
 				return
 			}
+			logger.Debugf("jitsi: bridge send broadcast len=%d", len(data))
 			s.sendBridgeFrame("", data)
 		case frame, ok := <-s.peerSendQueue:
 			if !ok {
@@ -1151,17 +1156,22 @@ func (s *Session) recvLoop() {
 
 	jSess := s.jSess.Load()
 	if jSess == nil || (s.onData == nil && s.onPeerData == nil) || !s.bridgeReady.Load() {
+		logger.Debugf("jitsi: recvLoop early exit jSess=%v onData=%v onPeerData=%v bridgeReady=%v",
+			jSess != nil, s.onData != nil, s.onPeerData != nil, s.bridgeReady.Load())
 		return
 	}
 	msgs := jSess.BridgeMessages()
 	if msgs == nil {
+		logger.Debugf("jitsi: recvLoop: BridgeMessages() returned nil, exiting")
 		return
 	}
+	logger.Debugf("jitsi: recvLoop started")
 	for {
 		select {
 		case <-s.done:
 			return
 		case msg, ok := <-msgs:
+			logger.Debugf("jitsi: recvLoop got msg ok=%v class=%q from=%q", ok, msg.Class, msg.From)
 			if !s.deliverBridgeMessage(msg, ok) {
 				return
 			}
@@ -1179,6 +1189,7 @@ func (s *Session) deliverBridgeMessage(msg j.BridgeMessage, ok bool) bool {
 		}
 		return false
 	}
+	logger.Debugf("jitsi: bridge msg class=%q from=%q len=%d", msg.Class, msg.From, len(msg.RawJSON))
 	payload, valid := bridgePayload(msg)
 	if !valid {
 		return true
@@ -1262,10 +1273,16 @@ func (s *Session) acceptEpochFrame(payload []byte) ([]byte, bool) {
 			receiverEpoch, s.localEpoch.Load())
 		return nil, false
 	}
+	// Drop untargeted (broadcast) frames from unknown or third-party senders.
+	// Broadcasts from our latched peer are always accepted — the server may
+	// send welcome frames as broadcasts before it learns our localEpoch.
 	if s.requireTargetedPeer && s.onPeerData == nil && receiverEpoch != s.localEpoch.Load() {
-		logger.Debugf("jitsi: drop untargeted bridge frame senderEpoch=0x%08x localEpoch=0x%08x",
-			senderEpoch, s.localEpoch.Load())
-		return nil, false
+		knownPeerEpoch := s.peerEpoch.Load()
+		if knownPeerEpoch != 0 && senderEpoch != knownPeerEpoch {
+			logger.Debugf("jitsi: drop untargeted bridge frame senderEpoch=0x%08x localEpoch=0x%08x",
+				senderEpoch, s.localEpoch.Load())
+			return nil, false
+		}
 	}
 	// Update the peer-epoch latch and ALWAYS accept the frame.
 	//

--- a/internal/engine/jitsi/jitsi.go
+++ b/internal/engine/jitsi/jitsi.go
@@ -1094,7 +1094,6 @@ func (s *Session) sendLoop() {
 			if !ok {
 				return
 			}
-			logger.Debugf("jitsi: bridge send broadcast len=%d", len(data))
 			s.sendBridgeFrame("", data)
 		case frame, ok := <-s.peerSendQueue:
 			if !ok {
@@ -1171,7 +1170,6 @@ func (s *Session) recvLoop() {
 		case <-s.done:
 			return
 		case msg, ok := <-msgs:
-			logger.Debugf("jitsi: recvLoop got msg ok=%v class=%q from=%q", ok, msg.Class, msg.From)
 			if !s.deliverBridgeMessage(msg, ok) {
 				return
 			}
@@ -1189,7 +1187,6 @@ func (s *Session) deliverBridgeMessage(msg j.BridgeMessage, ok bool) bool {
 		}
 		return false
 	}
-	logger.Debugf("jitsi: bridge msg class=%q from=%q len=%d", msg.Class, msg.From, len(msg.RawJSON))
 	payload, valid := bridgePayload(msg)
 	if !valid {
 		return true
@@ -1273,12 +1270,17 @@ func (s *Session) acceptEpochFrame(payload []byte) ([]byte, bool) {
 			receiverEpoch, s.localEpoch.Load())
 		return nil, false
 	}
-	// Drop untargeted (broadcast) frames from unknown or third-party senders.
-	// Broadcasts from our latched peer are always accepted — the server may
-	// send welcome frames as broadcasts before it learns our localEpoch.
+	// Drop untargeted (broadcast) frames unless they come from the peer we
+	// have already latched onto. The server's first reply to a client is
+	// always targeted (it latches the client's localEpoch from the client's
+	// initial SYN frame before smux ever emits a reply), so a legitimate
+	// welcome carries receiverEpoch == localEpoch and never reaches this
+	// branch. Untargeted frames here are therefore either a third-party
+	// olcrtc instance broadcasting before our peer does, or post-latch
+	// broadcasts from our own peer (which we keep accepting).
 	if s.requireTargetedPeer && s.onPeerData == nil && receiverEpoch != s.localEpoch.Load() {
 		knownPeerEpoch := s.peerEpoch.Load()
-		if knownPeerEpoch != 0 && senderEpoch != knownPeerEpoch {
+		if knownPeerEpoch == 0 || senderEpoch != knownPeerEpoch {
 			logger.Debugf("jitsi: drop untargeted bridge frame senderEpoch=0x%08x localEpoch=0x%08x",
 				senderEpoch, s.localEpoch.Load())
 			return nil, false
@@ -1842,7 +1844,7 @@ func (s *Session) WaitForPeer(ctx context.Context) error {
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return fmt.Errorf("wait for peer: %w", ctx.Err())
 		case <-time.After(pollInterval):
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -861,41 +861,8 @@ func (s *Server) acceptHandshake(ctx context.Context, sess *smux.Session) bool {
 }
 
 func (s *Server) servePeer(ps *peerSession) {
-	if ps.sessionID == "" {
-		s.sessMu.RLock()
-		hasControl := s.controlConn != nil
-		s.sessMu.RUnlock()
-		if !hasControl {
-			// No isolated control plane (e.g. datachannel in peer-routing mode):
-			// drive the handshake inline on this peer's smux session, mirroring
-			// the legacy path in waitHandshake/serveSingle.
-			if !s.acceptHandshake(s.baseCtx, ps.session) {
-				s.removePeerSession(ps.peerID, "handshake failed")
-				return
-			}
-			s.sessMu.RLock()
-			ps.sessionID = s.sessionID
-			ps.deviceID = s.deviceID
-			s.sessMu.RUnlock()
-		} else {
-			// Isolated control plane: spin-wait until acceptHandshake completes.
-			for {
-				if s.stopping() {
-					s.removePeerSession(ps.peerID, "closed")
-					return
-				}
-				s.sessMu.RLock()
-				sid := s.sessionID
-				did := s.deviceID
-				s.sessMu.RUnlock()
-				if sid != "" {
-					ps.sessionID = sid
-					ps.deviceID = did
-					break
-				}
-				time.Sleep(10 * time.Millisecond)
-			}
-		}
+	if ps.sessionID == "" && !s.establishPeerSession(ps) {
+		return
 	}
 	for {
 		if s.stopping() {
@@ -915,6 +882,53 @@ func (s *Server) servePeer(ps *peerSession) {
 			defer s.wg.Done()
 			s.handleStream(context.Background(), stream, ps.sessionID)
 		}()
+	}
+}
+
+// establishPeerSession completes the handshake for a freshly accepted peer
+// session and populates ps.sessionID/deviceID. It returns false if the peer
+// should be dropped (handshake failed or the server is shutting down).
+func (s *Server) establishPeerSession(ps *peerSession) bool {
+	s.sessMu.RLock()
+	hasControl := s.controlConn != nil
+	s.sessMu.RUnlock()
+	if !hasControl {
+		// No isolated control plane (e.g. datachannel in peer-routing mode):
+		// drive the handshake inline on this peer's smux session, mirroring
+		// the legacy path in waitHandshake/serveSingle.
+		if !s.acceptHandshake(s.baseCtx, ps.session) {
+			s.removePeerSession(ps.peerID, "handshake failed")
+			return false
+		}
+		s.sessMu.RLock()
+		ps.sessionID = s.sessionID
+		ps.deviceID = s.deviceID
+		s.sessMu.RUnlock()
+		return true
+	}
+	// Isolated control plane: spin-wait until acceptHandshake completes.
+	return s.waitPeerHandshake(ps)
+}
+
+// waitPeerHandshake blocks until the isolated control plane has completed the
+// handshake and published a session ID, copying it onto ps. Returns false if
+// the server stops before the handshake lands.
+func (s *Server) waitPeerHandshake(ps *peerSession) bool {
+	for {
+		if s.stopping() {
+			s.removePeerSession(ps.peerID, "closed")
+			return false
+		}
+		s.sessMu.RLock()
+		sid := s.sessionID
+		did := s.deviceID
+		s.sessMu.RUnlock()
+		if sid != "" {
+			ps.sessionID = sid
+			ps.deviceID = did
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -861,26 +861,40 @@ func (s *Server) acceptHandshake(ctx context.Context, sess *smux.Session) bool {
 }
 
 func (s *Server) servePeer(ps *peerSession) {
-	// In peer-routing mode the handshake runs on the isolated control KCP
-	// session (acceptHandshake). The first data frame may arrive before the
-	// control handshake completes, so we spin-wait here until sessionID is
-	// set. If the context is cancelled first we bail out cleanly.
 	if ps.sessionID == "" {
-		for {
-			if s.stopping() {
-				s.removePeerSession(ps.peerID, "closed")
+		s.sessMu.RLock()
+		hasControl := s.controlConn != nil
+		s.sessMu.RUnlock()
+		if !hasControl {
+			// No isolated control plane (e.g. datachannel in peer-routing mode):
+			// drive the handshake inline on this peer's smux session, mirroring
+			// the legacy path in waitHandshake/serveSingle.
+			if !s.acceptHandshake(s.baseCtx, ps.session) {
+				s.removePeerSession(ps.peerID, "handshake failed")
 				return
 			}
 			s.sessMu.RLock()
-			sid := s.sessionID
-			did := s.deviceID
+			ps.sessionID = s.sessionID
+			ps.deviceID = s.deviceID
 			s.sessMu.RUnlock()
-			if sid != "" {
-				ps.sessionID = sid
-				ps.deviceID = did
-				break
+		} else {
+			// Isolated control plane: spin-wait until acceptHandshake completes.
+			for {
+				if s.stopping() {
+					s.removePeerSession(ps.peerID, "closed")
+					return
+				}
+				s.sessMu.RLock()
+				sid := s.sessionID
+				did := s.deviceID
+				s.sessMu.RUnlock()
+				if sid != "" {
+					ps.sessionID = sid
+					ps.deviceID = did
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
 			}
-			time.Sleep(10 * time.Millisecond)
 		}
 	}
 	for {

--- a/internal/transport/datachannel/transport.go
+++ b/internal/transport/datachannel/transport.go
@@ -129,6 +129,16 @@ func (p *streamTransport) CanSend() bool {
 	return p.session.CanSend()
 }
 
+// WaitForPeer blocks until the remote peer is confirmed ready, or ctx expires.
+// Implements transport.PeerReadyTransport.
+func (p *streamTransport) WaitForPeer(ctx context.Context) error {
+	waiter, ok := p.session.(engine.PeerReadySession)
+	if !ok {
+		return nil
+	}
+	return waiter.WaitForPeer(ctx)
+}
+
 // Features describes the current datachannel transport semantics.
 func (p *streamTransport) Features() transport.Features {
 	return transport.Features{

--- a/internal/transport/datachannel/transport.go
+++ b/internal/transport/datachannel/transport.go
@@ -136,7 +136,10 @@ func (p *streamTransport) WaitForPeer(ctx context.Context) error {
 	if !ok {
 		return nil
 	}
-	return waiter.WaitForPeer(ctx)
+	if err := waiter.WaitForPeer(ctx); err != nil {
+		return fmt.Errorf("wait for peer: %w", err)
+	}
+	return nil
 }
 
 // Features describes the current datachannel transport semantics.

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -71,6 +71,13 @@ type PeerTransport interface {
 	SupportsPeerRouting() bool
 }
 
+// PeerReadyTransport is implemented by transports whose carrier can signal
+// when a remote peer has appeared. WaitForPeer blocks until the remote side
+// is confirmed ready (first epoch frame received), or ctx is cancelled.
+type PeerReadyTransport interface {
+	WaitForPeer(ctx context.Context) error
+}
+
 // Options is a marker for per-transport option structs. Each transport package
 // defines its own Options type (e.g. videochannel.Options) and registers a
 // factory that consumes it via type assertion. A nil Options is valid for

--- a/internal/transport/vp8channel/transport.go
+++ b/internal/transport/vp8channel/transport.go
@@ -584,7 +584,7 @@ func (p *streamTransport) WaitForPeer(ctx context.Context) error {
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return fmt.Errorf("wait for peer: %w", ctx.Err())
 		case <-time.After(pollInterval):
 		}
 	}

--- a/internal/transport/vp8channel/transport.go
+++ b/internal/transport/vp8channel/transport.go
@@ -573,6 +573,23 @@ func (p *streamTransport) WatchConnection(ctx context.Context) {
 	p.stream.WatchConnection(ctx)
 }
 
+// WaitForPeer blocks until the remote peer has been observed (first epoch
+// frame received), or ctx is cancelled.
+// Implements transport.PeerReadyTransport.
+func (p *streamTransport) WaitForPeer(ctx context.Context) error {
+	const pollInterval = 50 * time.Millisecond
+	for {
+		if p.peerEpoch.Load() != 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
 func (p *streamTransport) CanSend() bool {
 	if p.closed.Load() {
 		return false


### PR DESCRIPTION
## Summary

Four bug fixes that together make the handshake reliable for both `datachannel` (Jitsi) and `vp8channel` (Telemost) transports. All fixes are tested against real Jitsi and Telemost rooms.

### Bug 1 — XMPP keepalive half-open TCP (`jitsi.go`)

`xmppKeepalive` was fire-and-forget: on a half-open TCP connection it would silently succeed and the broken XMPP session would never reconnect. Fixed by using `SendIQWait` with a 15 s timeout — a missed ping now triggers a reconnect.

### Bug 2 — Server broadcast dropped by client (`jitsi.go`)

`requireTargetedPeer=true` caused the client to drop the server's broadcast welcome frame (receiver epoch = 0), so the client never received the session open and timed out. Fixed by only dropping frames from *unknown* peers; frames from the known server peer are always accepted.

### Bug 3 — Infinite spin-wait in `servePeer` for datachannel (`server.go`)

In peer-routing mode with `datachannel`, `installControlSession()` checks for the `ControlPlane` interface. `datachannel` does not implement it, so the function returned early without calling `acceptHandshake`, leaving `s.sessionID` unset and `servePeer()` spinning forever. Fixed by falling back to the legacy inline `acceptHandshake` path when there is no control connection.

### Bug 4 — smux SYN race: client sends before server opens bridge

The client could reach bridge-ready state ~2 s before the server. The smux SYN frame sent at that moment was dropped by the JVB (server datachannel not yet open), and smux does not retransmit SYN, so `AcceptStream` on the server side blocked indefinitely.

Fixed by adding `WaitForPeer(ctx)` — a lightweight 50 ms poll on `peerEpoch` — called between transport `Connect()` and opening the smux mux. This guarantees at least one epoch broadcast from the server has been received (i.e. the server's bridge is open) before the client sends any smux frames. Implemented for both `datachannel` and `vp8channel` transports.

## Test plan

- [x] Jitsi datachannel: connected on home network and mobile (МТС), traffic exits through OCI node
- [x] Telemost vp8channel: connected, KCP started, session opened
- [x] Multiple reconnects stable (no spin-wait, no half-open hang)
- [x] `vp8channel` confirmed working with WaitForPeer