### PR TITLE
fix(vp8channel): add per-packet crc to drop carrier-corrupted kcp data

### DIFF
--- a/internal/transport/vp8channel/integrity_test.go
+++ b/internal/transport/vp8channel/integrity_test.go
@@ -1,0 +1,108 @@
+package vp8channel
+
+import (
+	"bytes"
+	"math/rand/v2"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// corruptPump forwards packets from `from` into `to.deliver`, flipping a byte
+// in the KCP body of a fraction of them. It models a carrier (an SFU that may
+// transcode our fake-VP8 stream) that perturbs payload bytes without dropping
+// the packet outright. KCP runs with block=nil, so before the wire CRC was
+// added a corrupt-but-parseable segment rode through as valid in-order data
+// and broke the muxconn AEAD above it (issue #109).
+func corruptPump(
+	stop <-chan struct{},
+	from <-chan []byte,
+	to *kcpRuntime,
+	corruptRatio float64,
+	seed uint64,
+	corrupted *atomic.Uint64,
+) {
+	if seed == 0 {
+		seed = 1
+	}
+	rng := rand.New(rand.NewPCG(seed, seed^0x9E3779B97F4A7C15)) //nolint:gosec // weak RNG fine for test fixtures
+	for {
+		select {
+		case <-stop:
+			return
+		case pkt := <-from:
+			if len(pkt) <= epochHdrLen {
+				continue
+			}
+			body := append([]byte(nil), pkt[epochHdrLen:]...)
+			// Flip a byte in the KCP-packet region, but leave the trailing
+			// CRC intact so the corruption is what the CRC must catch.
+			if len(body) > wireCRCLen+1 && rng.Float64() < corruptRatio {
+				i := rng.IntN(len(body) - wireCRCLen)
+				body[i] ^= 0xFF
+				if corrupted != nil {
+					corrupted.Add(1)
+				}
+			}
+			to.deliver(body)
+		}
+	}
+}
+
+// TestKCPDropsCarrierCorruptedPackets is the issue #109 regression guard. With
+// ~15% of packets corrupted in flight, every message must still arrive intact:
+// the wire CRC drops the corrupt segments and KCP retransmits them. Without the
+// CRC, corrupt bytes reach the receiver and checkMessages fails - exactly the
+// "chacha20poly1305: message authentication failed" path one layer up.
+func TestKCPDropsCarrierCorruptedPackets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integrity chaos test in -short mode")
+	}
+	msgs := [][]byte{
+		[]byte("alpha"),
+		bytes.Repeat([]byte("B"), 2000),
+		bytes.Repeat([]byte("C"), 8000),
+		bytes.Repeat([]byte("D"), 20000),
+	}
+
+	a2b := make(chan []byte, 1024)
+	b2a := make(chan []byte, 1024)
+	cb, doneB, getRecv := buildReceiver(len(msgs))
+
+	rtA, err := startKCP(a2b, nil, testEpochHdr(1))
+	if err != nil {
+		t.Fatalf("startKCP A: %v", err)
+	}
+	defer rtA.close()
+	rtB, err := startKCP(b2a, cb, testEpochHdr(2))
+	if err != nil {
+		t.Fatalf("startKCP B: %v", err)
+	}
+	defer rtB.close()
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	var corrupted atomic.Uint64
+	go corruptPump(stop, a2b, rtB, 0.15, 0xD15EA5E, &corrupted)
+	// Return path stays clean so ACKs flow back reliably.
+	go pumpPackets(stop, b2a, rtA)
+
+	for _, m := range msgs {
+		if err := rtA.send(m); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+	}
+
+	select {
+	case <-doneB:
+	case <-time.After(20 * time.Second):
+		got := getRecv()
+		t.Fatalf("timeout: got %d/%d messages, corrupted=%d", len(got), len(msgs), corrupted.Load())
+	}
+	checkMessages(t, getRecv(), msgs)
+	if corrupted.Load() == 0 {
+		t.Fatal("corrupt pump flipped no bytes - corruption injection broken")
+	}
+	t.Logf("delivered %d msgs intact despite %d corrupted packets", len(msgs), corrupted.Load())
+}

--- a/internal/transport/vp8channel/kcpconn.go
+++ b/internal/transport/vp8channel/kcpconn.go
@@ -5,10 +5,27 @@
 package vp8channel
 
 import (
+	"encoding/binary"
+	"hash/crc32"
 	"net"
 	"sync"
 	"time"
 )
+
+// wireCRCLen is the size of the CRC32 trailer appended to every KCP packet
+// on the wire. KCP is handed to kcp-go with block=nil (no FEC, no checksum),
+// so the vp8channel carrier - a video stream an SFU may transcode or reorder -
+// has no integrity protection at all. A real UDP datagram carries a checksum
+// and is dropped on mismatch; without an equivalent, a single flipped byte
+// rides through KCP as valid in-order data and corrupts the encrypted muxconn
+// stream above it, tripping "chacha20poly1305: message authentication failed"
+// (issue #109). The CRC restores UDP-equivalent semantics: a corrupted packet
+// is dropped so KCP retransmits it.
+const wireCRCLen = 4
+
+// crcTable uses the Castagnoli polynomial for hardware-accelerated checksums
+// (SSE4.2 on amd64) on this throughput hot path.
+var crcTable = crc32.MakeTable(crc32.Castagnoli) //nolint:gochecknoglobals // shared read-only CRC table
 
 func fakeUDPAddr() *net.UDPAddr {
 	return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1}
@@ -62,11 +79,22 @@ func newKCPConn(out chan<- []byte, inboundCap int, epochHdr [epochHdrLen]byte) *
 	}
 }
 
-// deliver hands an incoming wire payload to the KCP read loop. Drops on
+// deliver hands an incoming wire payload to the KCP read loop. The trailing
+// CRC32 is verified and stripped first: a mismatch means the carrier corrupted
+// the packet, so we drop it (KCP retransmits via SACK) instead of feeding
+// garbage into KCP and, ultimately, the muxconn AEAD (issue #109). Drops on
 // overflow are intentional - KCP will detect the loss via SACK and retransmit.
 func (c *kcpConn) deliver(payload []byte) {
-	cp := make([]byte, len(payload))
-	copy(cp, payload)
+	if len(payload) < wireCRCLen {
+		return
+	}
+	body := payload[:len(payload)-wireCRCLen]
+	want := binary.BigEndian.Uint32(payload[len(payload)-wireCRCLen:])
+	if crc32.Checksum(body, crcTable) != want {
+		return
+	}
+	cp := make([]byte, len(body))
+	copy(cp, body)
 	select {
 	case c.in <- cp:
 	case <-c.closed:
@@ -102,11 +130,14 @@ func (c *kcpConn) ReadFrom(p []byte) (int, net.Addr, error) {
 }
 
 func (c *kcpConn) WriteTo(p []byte, _ net.Addr) (int, error) {
-	buf := make([]byte, epochHdrLen+len(p))
+	// Layout: [epoch header][KCP packet p][CRC32(p)]. The receiver strips the
+	// epoch header before deliver(), which then verifies and strips the CRC.
+	buf := make([]byte, epochHdrLen+len(p)+wireCRCLen)
 	c.hdrMu.RLock()
 	copy(buf, c.epochHdr[:])
 	c.hdrMu.RUnlock()
 	copy(buf[epochHdrLen:], p)
+	binary.BigEndian.PutUint32(buf[epochHdrLen+len(p):], crc32.Checksum(p, crcTable))
 
 	c.mu.Lock()
 	deadline := c.wDeadline

--- a/internal/transport/vp8channel/kcpconn_test.go
+++ b/internal/transport/vp8channel/kcpconn_test.go
@@ -2,7 +2,9 @@ package vp8channel
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
+	"hash/crc32"
 	"net"
 	"testing"
 	"time"
@@ -26,15 +28,28 @@ func TestKCPConnReadWriteDeadlinesAndClose(t *testing.T) {
 		t.Fatalf("WriteTo() = (%d, %v), want payload length", n, err)
 	}
 	wire := <-out
-	if !bytes.Equal(wire[:epochHdrLen], hdr[:]) || string(wire[epochHdrLen:]) != "payload" {
+	// Wire layout is [epoch header][KCP packet][CRC32(packet)].
+	body := wire[epochHdrLen : len(wire)-wireCRCLen]
+	if !bytes.Equal(wire[:epochHdrLen], hdr[:]) || string(body) != "payload" {
 		t.Fatalf("wire packet = %v", wire)
 	}
 
-	conn.deliver([]byte("incoming"))
+	// deliver expects the CRC trailer WriteTo appends; build it the same way.
+	incoming := append([]byte("incoming"), make([]byte, wireCRCLen)...)
+	binary.BigEndian.PutUint32(incoming[len("incoming"):], crc32.Checksum([]byte("incoming"), crcTable))
+	conn.deliver(incoming)
 	buf := make([]byte, 64)
 	n, addr, err := conn.ReadFrom(buf)
 	if err != nil || addr == nil || string(buf[:n]) != "incoming" {
 		t.Fatalf("ReadFrom() = (%d, %v, %v), payload %q", n, addr, err, buf[:n])
+	}
+
+	// A corrupted packet (CRC mismatch) must be dropped, not delivered.
+	corrupt := append([]byte("incoming"), make([]byte, wireCRCLen)...)
+	binary.BigEndian.PutUint32(corrupt[len("incoming"):], 0xDEADBEEF)
+	conn.deliver(corrupt)
+	if len(conn.in) != 0 {
+		t.Fatalf("corrupt packet was delivered, in-queue len = %d", len(conn.in))
 	}
 
 	if err := conn.Close(); err != nil {


### PR DESCRIPTION
## Что меняет PR

vp8channel отдаёт KCP в kcp-go с `block=nil` - ни FEC, ни контрольной суммы. Реальная UDP-датаграмма несёт checksum и дропается при искажении; у нашего фейк-VP8 carrier такой защиты нет. SFU, который может транскодировать/реордерить видеопоток, изредка искажает байты пакета, KCP принимает битый, но парсящийся сегмент как валидные in-order данные, отдаёт мусор наверх в muxconn, и его AEAD падает с `chacha20poly1305: message authentication failed`. Зашифрованный smux-поток рассинхронизируется, сессия пересобирается - in-flight curl рвётся, но пов��орный запуск работает.

PR добавляет CRC32 (Castagnoli) на каждый KCP-пакет на уровне kcpConn: `WriteTo` дописывает CRC в хвост, `deliver` проверяет и срезает его, битый пакет дропается - KCP ретрансмитит через SACK. Восстанавливает UDP-эквивалентную семантику. CRC оборачивает сырой KCP-пакет под слоем батчинга, поэтому одинаково покрывает и батч, и одиночные пакеты.

## Связанные issue

Closes #109

## Тип изменения

- [x] fix - исправление бага

## Область

- [x] transport / channel (`pkg/olcrtc/tunnel`, datachannel/vp8/sei/video)

## Как тестировалось

- Provider: telemost
- Transport: vp8channel
- ОС: linux
- Сценарий:

```text
Добавлен integrity_test.go: corruptPump искажает ~15% пакетов на carrier-seam,
все сообщения всё равно доходят целыми (CRC дропает битые, KCP ретрансмитит).
Снятие CRC-проверки роняет тест (битые байты доходят наверх) - это и есть
воспроизведение бага в unit-форме. kcpconn_test проверяет дроп пакета с битым CRC.

mage check зелёный: build + golangci-lint v2 0 issues + все тесты с -race (вкл. e2e).
```

## Совместимость

- [x] Конфиг (`*.yaml`) совместим с предыдущей версией
- [ ] Wire-протокол совместим (клиент старой версии работает с новым сервером и наоборот)
- [x] Публичный API в `pkg/` не сломан

Wire-формат vp8channel меняется: к каждому KCP-пакету добавляется 4-байтный CRC-хвост. Старый и новый peer по vp8channel несовместимы - оба конца надо обновить вместе. Другие транспорты (datachannel/sei/video) не затронуты.

## Чек-лист

- [x] Локально прогнаны `mage lint` и `mage test`
- [x] Добавлены/обновлены тесты, где это имеет смысл
- [x] Обновлена документация (`docs/`, примеры в `docs/examples/`, README), если поведение/конфиг изменились
- [x] В коде нет закомментированного мусора, отладочных `fmt.Println`, токенов и ключей
- [x] Я согласен с лицензией репозитория и тем, что мой вклад выпускается под ней
