### PR TITLE
docs: rewrite fast guide around srv.sh/cnc.sh scripts

### DIFF
--- a/docs/fast.md
+++ b/docs/fast.md
@@ -9,151 +9,342 @@
 
 </div>
 
-# Quick start
+# Quick start (via scripts)
 
 > **Important:** always check that the video call service you need is on the allow lists, that it works in your network, and so on. If not, use another one.
 
-This method runs `olcrtc` as an ordinary native binary. You need Go 1.26+, mage, git and curl.
+This is the easiest way. Everything runs inside a [Podman](https://en.wikipedia.org/wiki/Podman) container. The script does everything itself: clones the [sources](https://github.com/openlibrecommunity/olcrtc), builds the binary in a container, generates a config and starts it.
 
-## Install dependencies
+The project is in beta. For issues: t.me/openlibrecommunity
+
+If you want to build the binary by hand, see [manual.md](manual.md).
+
+---
+
+## What to install
+
+### git
 
 ```sh
-apt install git curl        # Debian / Ubuntu / Mint
-pacman -S git curl          # Arch / CachyOS / Manjaro
-dnf install git curl        # Fedora / RHEL / CentOS
+apt install git        # Debian / Ubuntu / Mint
+pacman -S git          # Arch / CachyOS / Manjaro
+dnf install git        # Fedora / RHEL / CentOS
 ```
 
-Install Go 1.26+ and mage:
+### curl
 
 ```sh
-go install github.com/magefile/mage@latest
-echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
+apt install curl       # Debian / Ubuntu / Mint
+pacman -S curl         # Arch / CachyOS / Manjaro
+dnf install curl       # Fedora / RHEL / CentOS
 ```
 
-If the machine has less than 4 GB RAM, enable swap before building:
+### podman
+
+You do not have to install it up front - the script installs podman itself if it is missing. But if you want:
+
+```sh
+apt install podman     # Debian / Ubuntu / Mint
+pacman -S podman       # Arch / CachyOS / Manjaro
+dnf install podman     # Fedora / RHEL / CentOS
+```
+
+### swap (RAM)
+
+If the machine has less than 4 GB RAM, the build may crash. **Enable SWAP**:
 
 ```sh
 sudo fallocate -l 4G /swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile
 ```
 
-## Build
+---
+
+## Step 1: Clone the repository
 
 ```sh
 git clone https://github.com/openlibrecommunity/olcrtc --recurse-submodules
 cd olcrtc
-mage build
 ```
 
-The binary lands in `build/`, for example:
+<img src="asset/gitclone.png" alt="git clone" width="800">
+
+---
+
+## Step 2: Run the server
+
+On the machine the traffic should go through (VPS, server abroad, home PC):
 
 ```sh
-./build/olcrtc-linux-amd64
+./script/srv.sh
 ```
 
-## Generate a key
+The script installs podman if needed, clones the current code, builds the binary in a container and starts the server. Then it asks a few questions.
 
-The key must match on the server and the client.
+#### `srv.sh` flags
+
+| Flag | What it does |
+|---|---|
+| `--branch=<name>` | Use another repository branch instead of `master` |
+| `--no-cache` | Purge the Go cache (`~/.cache/olcrtc`) before building - rebuild from scratch |
 
 ```sh
-openssl rand -hex 32
+./script/srv.sh --no-cache               # build from scratch
+./script/srv.sh --branch=dev --no-cache  # branch dev, no cache
 ```
 
-## Run the server
+### Carrier (which service carries the traffic)
 
-Create `server.yaml`:
-
-> **Important:** always check that the video call service you need is on the allow lists, that it works in your network, and so on. If not, use another one.
-
-```yaml
-mode: srv
-auth:
-  provider: jitsi
-room:
-  
-  id: "https://meet.small-dm.ru/REPLACE_ME_WITH_ROOM_ID" # or https://meet.small-dm.ru/ROOM  or  https://meet1.arbitr.ru/ROOM  or  https://meet.handyweb.org/ROOM etc.
-
-crypto:
-  key: "REPLACE_ME_WITH_64_HEX_CHARS"
-net:
-  transport: datachannel
-  dns: "8.8.8.8:53"
-data: data
+```
+Select carrier:
+  1) jitsi
+  2) telemost
+  3) wbstream
+Enter choice [1-3, default: 1]:
 ```
 
-Run it:
+**Default is `jitsi`** - stable on datachannel, no registration needed, easy to self-host. Full compatibility matrix in [settings.md](settings.md).
+
+### Transport (how the data is carried)
+
+```
+Select transport:
+  1) datachannel
+  2) videochannel
+  3) seichannel
+  4) vp8channel
+Enter choice [1-4, default: 1]:
+```
+
+Recommendations:
+- **datachannel** - fastest, lowest ping. Stable with `jitsi`. **WBStream DC does not work** in the normal guest flow. **Telemost removed DC**.
+- **vp8channel** - works with telemost and wbstream, fast, but high ping.
+- **seichannel** - works only with wbstream, slow, but low ping.
+- **videochannel** - works with wbstream reliably, with telemost when possible; slowest and highest ping.
+
+**Recommended combo: `jitsi + datachannel`**. Alternative: `wbstream + vp8channel`.
+
+### Jitsi server (carrier jitsi only)
+
+```
+Choose a Jitsi server (check in the browser which one works in your network):
+  1) https://meet.small-dm.ru/
+  2) https://meet1.arbitr.ru/
+  3) https://meet.handyweb.org/
+  4) Other (enter manually)
+Enter number [1-4, default: 1]:
+```
+
+Pick the one that **opens in your browser**. Any public or self-hosted Jitsi Meet works - choose `4` and enter your URL.
+
+### Room (carrier jitsi only)
+
+```
+Room options:
+  1) Auto-generate new room (recommended)
+  2) Use specific room name or URL
+Enter choice [1-2, default: 1]:
+```
+
+- **1) Auto-generate** - the script picks a room name on the chosen server. Recommended.
+- **2) Specific** - enter a room name (`myroom`) or a full URL (`https://meet.small-dm.ru/myroom`).
+
+For **telemost** and **wbstream** the Jitsi menu is not shown - the script asks for the Room ID directly. Create a room on the site ([telemost](https://telemost.yandex.ru/), [wbstream](https://stream.wb.ru)) and paste its ID.
+
+### DNS
+
+```
+DNS server [default: 8.8.8.8:53]:
+```
+
+Press Enter. No need to change it without a reason; if you want - `77.88.8.8:53` or your provider's DNS.
+
+### SOCKS5 proxy for egress
+
+```
+Use SOCKS5 proxy for egress? (y/N):
+```
+
+If not needed - just Enter. If the server itself should go through an external proxy - type `y` and enter the address and port.
+
+### Transport settings (videochannel only)
+
+```
+Video codec:
+  1) qrcode
+  2) tile (requires 1080x1080)
+Enter choice [1-2, default: 1]:
+```
+
+- **qrcode** - QR codes, configurable resolution, stable, slow.
+- **tile** - tile codec, 1080x1080 only, Reed-Solomon support, faster but less stable.
+
+Then the script asks for width/height, QR error correction, fragment size (or tile params), FPS, bitrate and hardware acceleration (`none`/`nvenc`). Press Enter for defaults.
+
+### Transport settings (vp8channel only)
+
+```
+VP8 FPS [default: 25]:
+VP8 batch size (frames per tick) [default: 1]:
+```
+
+Press Enter if `25` and `1` are fine.
+
+### Transport settings (seichannel only)
+
+```
+SEI FPS [default: 60]:
+SEI batch size (frames per tick) [default: 64]:
+SEI fragment size in bytes [default: 900]:
+SEI ACK timeout in milliseconds [default: 2000]:
+```
+
+Press Enter on all - the defaults are optimal.
+
+### Config comment
+
+```
+Enter a comment for the config (default: olc - t.me/openlibrecommunity):
+```
+
+This is the label for the resulting `olcrtc://` URI. You can leave it empty (Enter).
+
+### Result
+
+After startup the script prints the container name, carrier, transport, Room ID, the **encryption key** and a ready `olcrtc://` URI:
+
+```
+[+] Server started successfully!
+
+Container name: olcrtc-server-xxxxxxxx
+Carrier:        jitsi
+Transport:      datachannel
+Room ID/URL:    https://meet.small-dm.ru/olcrtc-xxxxxxxx
+Encryption key: d823fa01cb3e0609b67322f7cf984c4ee2e294936fc24ef38c9e59f4799...
+
+uri: olcrtc://jitsi?datachannel@https://meet.small-dm.ru/olcrtc-xxxxxxxx#<key>$olc - t.me/openlibrecommunity
+```
+
+**Save the Room ID and the encryption key** - the client needs them. The key is also saved to `~/.olcrtc_key` and reused on later runs.
+
+---
+
+## Step 3: Run the client
+
+On your machine (home PC, laptop):
 
 ```sh
-./build/olcrtc-linux-amd64 server.yaml
+git clone https://github.com/openlibrecommunity/olcrtc --recurse-submodules
+cd olcrtc
+./script/cnc.sh
 ```
 
-## Run the client
+Answer the same questions as on the server - **auth, transport and room ID must match**. For jitsi the script asks for the same server choice and room name/URL.
 
-Create `client.yaml` on the client machine. `auth.provider`, `room.id`, `crypto.key` and `net.transport` must match the server.
+When it asks for the key:
 
-> **Important:** always check that the video call service you need is on the allow lists, that it works in your network, and so on. If not, use another one.
-
-```yaml
-mode: cnc
-auth:
-  provider: jitsi
-room:
-  id: "https://meet.small-dm.ru/REPLACE_ME_WITH_ROOM_ID" # or https://meet.small-dm.ru/ROOM  or  https://meet1.arbitr.ru/ROOM  or  https://meet.handyweb.org/ROOM etc.
-crypto:
-  key: "REPLACE_ME_WITH_64_HEX_CHARS"
-net:
-  transport: datachannel
-  dns: "8.8.8.8:53"
-socks:
-  host: "127.0.0.1"
-  port: 8808
-data: data
+```
+Enter Encryption Key (hex):
 ```
 
-Run it:
+Paste the key from the server (64 hex characters).
 
-```sh
-./build/olcrtc-linux-amd64 client.yaml
+### SOCKS5: address, port, auth
+
+```
+SOCKS5 ip [default: 127.0.0.1]:
+SOCKS5 port [default: 8808]:
+SOCKS5 username (leave empty to disable auth):
 ```
 
-After startup SOCKS5 listens on `127.0.0.1:8808`.
+Press Enter for address and port - the proxy comes up on `127.0.0.1:8808`. If you want login/password protection - enter the username, then the password. When binding outside loopback (not `127.*`) a username and password are required.
 
-## Verify
+### Result
+
+```
+[+] Client started successfully!
+
+Container name: olcrtc-client-xxxxxxxx
+Auth:           jitsi
+Transport:      datachannel
+Room ID/URL:    https://meet.small-dm.ru/olcrtc-xxxxxxxx
+SOCKS5 proxy:   127.0.0.1:8808
+```
+
+---
+
+## Step 4: Verify
 
 ```sh
 curl --socks5-hostname 127.0.0.1:8808 https://icanhazip.com
 ```
 
-It should return the server IP.
+It should return your server IP.
+
+Or route all traffic through the proxy:
+
+```sh
+export all_proxy=socks5h://127.0.0.1:8808
+curl https://icanhazip.com
+```
+
+---
 
 ## Control
 
-Stop a manual run with `Ctrl+C`.
-
-If the process runs in the background:
+### Logs
 
 ```sh
-pgrep -af olcrtc
-kill <pid>
+podman ps --filter name=olcrtc
+podman logs -f olcrtc-server-xxxxxxxx   # on the server
+podman logs -f olcrtc-client-xxxxxxxx   # on the client
 ```
 
-Update:
+### Stop
 
 ```sh
-git pull --recurse-submodules
-mage build
+podman stop olcrtc-server-xxxxxxxx
+podman stop olcrtc-client-xxxxxxxx
 ```
 
-Restart the server and the client with the same YAML configs.
+Stop all olcrtc containers at once:
 
-## Multiple instances
-
-You can run several servers or clients on one machine: create a separate YAML for each instance. For clients use different SOCKS5 ports:
-
-```yaml
-socks:
-  host: "127.0.0.1"
-  port: 8809
+```sh
+podman stop $(podman ps -q --filter name=olcrtc)
 ```
 
-All settings and the compatibility matrix: [settings.md](settings.md). Detailed manual build: [manual.md](manual.md).
+---
+
+## Update a running instance
+
+A running container does not update itself: it keeps the binary built at start time. To move to the current code, stop the old container and run the script again.
+
+```sh
+cd olcrtc
+git pull --recurse-submodules          # update local scripts
+podman stop olcrtc-server-xxxxxxxx     # stop the old container
+./script/srv.sh --no-cache             # start again with fresh code
+```
+
+`--no-cache` is optional but guarantees a clean rebuild. On the rerun use the same `auth`, `transport`, `room ID` and key. The server key lives in `~/.olcrtc_key` and is reused automatically.
+
+---
+
+## Multiple instances on one machine
+
+You can run several servers or clients on one machine - each run creates a container with a unique name (`olcrtc-server-<random>`), they do not conflict.
+
+```sh
+./script/srv.sh   # first instance - e.g. jitsi + datachannel
+./script/srv.sh   # second instance - e.g. wbstream + vp8channel
+```
+
+On the client run a separate `cnc.sh` for each instance with **different SOCKS5 ports** to switch between them:
+
+```sh
+./script/cnc.sh   # first client - port 8808 (default)
+./script/cnc.sh   # second client - set port 8809
+```
+
+---
+
+All settings and the compatibility matrix: [settings.md](settings.md). Manual build without scripts: [manual.md](manual.md).

--- a/docs/fast.ru.md
+++ b/docs/fast.ru.md
@@ -9,151 +9,342 @@
 
 </div>
 
-# Быстрый старт
+# Быстрый старт (через скрипты)
 
-> **Важно:** Обязательно проверяйте, есть ли сервис видеозвонков у вас в белых списках, работает ли он и так далее, если нет - используйте другой.
+> **Важно:** Обязательно проверяйте, есть ли сервис видеозвонков у вас в белых списках, работает ли он в вашей сети и так далее. Если нет - используйте другой.
 
-Этот способ запускает `olcrtc` как обычный нативный бинарник. Нужны Go 1.26+, mage, git и curl.
+Это самый простой способ. Всё запускается в контейнере [Podman](https://ru.wikipedia.org/wiki/Podman). Скрипт делает всё сам: клонирует [исходники](https://github.com/openlibrecommunity/olcrtc), собирает бинарник в контейнере, генерирует конфиг и запускает.
 
-## Установить зависимости
+Проект в бете. По проблемам: t.me/openlibrecommunity
+
+Хочешь собрать бинарник руками - смотри [manual.ru.md](manual.ru.md).
+
+---
+
+## Что нужно установить
+
+### git
 
 ```sh
-apt install git curl        # Debian / Ubuntu / Mint
-pacman -S git curl          # Arch / CachyOS / Manjaro
-dnf install git curl        # Fedora / RHEL / CentOS
+apt install git        # Debian / Ubuntu / Mint
+pacman -S git          # Arch / CachyOS / Manjaro
+dnf install git        # Fedora / RHEL / CentOS
 ```
 
-Установи Go 1.26+ и mage:
+### curl
 
 ```sh
-go install github.com/magefile/mage@latest
-echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
+apt install curl       # Debian / Ubuntu / Mint
+pacman -S curl         # Arch / CachyOS / Manjaro
+dnf install curl       # Fedora / RHEL / CentOS
 ```
 
-Если на машине меньше 4 ГБ RAM, включи swap перед сборкой:
+### podman
+
+Можно не ставить заранее - скрипт сам поставит podman, если его нет. Но при желании:
+
+```sh
+apt install podman     # Debian / Ubuntu / Mint
+pacman -S podman       # Arch / CachyOS / Manjaro
+dnf install podman     # Fedora / RHEL / CentOS
+```
+
+### swap (ОЗУ)
+
+Если на машине меньше 4 ГБ оперативной памяти, сборка может вылетать. **Включите SWAP**:
 
 ```sh
 sudo fallocate -l 4G /swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile
 ```
 
-## Собрать
+---
+
+## Шаг 1: Скачать репозиторий
 
 ```sh
 git clone https://github.com/openlibrecommunity/olcrtc --recurse-submodules
 cd olcrtc
-mage build
 ```
 
-Бинарник появится в `build/`, например:
+<img src="asset/gitclone.png" alt="git clone" width="800">
+
+---
+
+## Шаг 2: Запустить сервер
+
+На машине, через которую должен идти трафик (VPS, сервер за рубежом, домашний ПК):
 
 ```sh
-./build/olcrtc-linux-amd64
+./script/srv.sh
 ```
 
-## Сгенерировать ключ
+Скрипт сам поставит podman при необходимости, склонирует актуальный код, соберёт бинарник в контейнере и запустит сервер. Дальше он задаст вопросы.
 
-Ключ должен совпадать на сервере и клиенте.
+#### Флаги `srv.sh`
+
+| Флаг | Что делает |
+|---|---|
+| `--branch=<name>` | Использовать другую ветку репозитория вместо `master` |
+| `--no-cache` | Очистить Go-кеш (`~/.cache/olcrtc`) перед сборкой - пересобрать с нуля |
 
 ```sh
-openssl rand -hex 32
+./script/srv.sh --no-cache               # сборка с нуля
+./script/srv.sh --branch=dev --no-cache  # ветка dev, без кеша
 ```
 
-## Запустить сервер
+### Carrier (на каком сервисе передавать трафик)
 
-Создай `server.yaml`:
-
-> **Важно:** Обязательно проверяйте, есть ли сервис видеозвонков у вас в белых списках, работает ли он и так далее, если нет - используйте другой.
-
-```yaml
-mode: srv
-auth:
-  provider: jitsi
-room:
-  
-  id: "https://meet.small-dm.ru/REPLACE_ME_WITH_ROOM_ID" # или же https://meet.small-dm.ru/ROOM  или  https://meet1.arbitr.ru/ROOM  или  https://meet.handyweb.org/ROOM и т.д.
-
-crypto:
-  key: "REPLACE_ME_WITH_64_HEX_CHARS"
-net:
-  transport: datachannel
-  dns: "8.8.8.8:53"
-data: data
+```
+Select carrier:
+  1) jitsi
+  2) telemost
+  3) wbstream
+Enter choice [1-3, default: 1]:
 ```
 
-Запусти:
+**По умолчанию `jitsi`** - стабильно работает на datachannel, не требует регистрации, легко поднимается на своём сервере. Полная матрица совместимости - в [settings.ru.md](settings.ru.md).
+
+### Transport (как именно передавать данные)
+
+```
+Select transport:
+  1) datachannel
+  2) videochannel
+  3) seichannel
+  4) vp8channel
+Enter choice [1-4, default: 1]:
+```
+
+Рекомендации:
+- **datachannel** - самый быстрый, минимальный пинг. Стабильно работает с `jitsi`. **WBStream DC не работает** в обычном guest flow. **Telemost удалил DC**.
+- **vp8channel** - работает с telemost и wbstream, быстрый, но большой пинг.
+- **seichannel** - работает только с wbstream, медленный, но мелкий пинг.
+- **videochannel** - работает с wbstream стабильно, с telemost по возможности; самый медленный и с большим пингом.
+
+**Рекомендуемая комбинация: `jitsi + datachannel`**. Альтернатива: `wbstream + vp8channel`.
+
+### Jitsi-сервер (только для carrier jitsi)
+
+```
+Выберите Jitsi-сервер (проверьте в браузере, какой работает в вашей сети):
+  1) https://meet.small-dm.ru/
+  2) https://meet1.arbitr.ru/
+  3) https://meet.handyweb.org/
+  4) Другой (ввести вручную)
+Введите номер [1-4, по умолчанию: 1]:
+```
+
+Выбери тот сервер, который **открывается в твоём браузере**. Подойдёт любой публичный или self-hosted Jitsi Meet - выбери `4` и введи свой URL.
+
+### Room (только для carrier jitsi)
+
+```
+Room options:
+  1) Auto-generate new room (recommended)
+  2) Use specific room name or URL
+Enter choice [1-2, default: 1]:
+```
+
+- **1) Auto-generate** - скрипт сам придумает имя комнаты на выбранном сервере. Рекомендуется.
+- **2) Specific** - введи имя комнаты (`myroom`) или полный URL (`https://meet.small-dm.ru/myroom`).
+
+Для **telemost** и **wbstream** Jitsi-меню не показывается - скрипт спросит Room ID напрямую. Создай руму через сайт ([telemost](https://telemost.yandex.ru/), [wbstream](https://stream.wb.ru)) и вставь её ID.
+
+### DNS
+
+```
+DNS server [default: 8.8.8.8:53]:
+```
+
+Нажми Enter. Менять не нужно без причины; при желании - `77.88.8.8:53` или DNS твоего провайдера.
+
+### SOCKS5-прокси для исходящего трафика
+
+```
+Use SOCKS5 proxy for egress? (y/N):
+```
+
+Если не нужно - просто Enter. Если сервер сам должен ходить через внешний прокси - введи `y` и укажи адрес и порт.
+
+### Параметры транспорта (только videochannel)
+
+```
+Video codec:
+  1) qrcode
+  2) tile (requires 1080x1080)
+Enter choice [1-2, default: 1]:
+```
+
+- **qrcode** - QR-коды, настраиваемое разрешение, стабильный, медленный.
+- **tile** - тайловый кодек, только 1080x1080, поддержка Reed-Solomon, быстрее, но менее стабилен.
+
+Дальше скрипт спросит ширину/высоту, коррекцию ошибок QR, размер фрагмента (или параметры tile), FPS, битрейт и аппаратное ускорение (`none`/`nvenc`). Для значений по умолчанию жми Enter.
+
+### Параметры транспорта (только vp8channel)
+
+```
+VP8 FPS [default: 25]:
+VP8 batch size (frames per tick) [default: 1]:
+```
+
+Жми Enter, если устраивают `25` и `1`.
+
+### Параметры транспорта (только seichannel)
+
+```
+SEI FPS [default: 60]:
+SEI batch size (frames per tick) [default: 64]:
+SEI fragment size in bytes [default: 900]:
+SEI ACK timeout in milliseconds [default: 2000]:
+```
+
+Жми Enter на всех - значения по умолчанию оптимальны.
+
+### Комментарий к конфигу
+
+```
+Enter a comment for the config (default: olc - t.me/openlibrecommunity):
+```
+
+Это подпись для итогового `olcrtc://` URI. Можно оставить пустым (Enter).
+
+### Результат
+
+После запуска скрипт выведет имя контейнера, carrier, transport, Room ID, **ключ шифрования** и готовый `olcrtc://` URI:
+
+```
+[+] Server started successfully!
+
+Container name: olcrtc-server-xxxxxxxx
+Carrier:        jitsi
+Transport:      datachannel
+Room ID/URL:    https://meet.small-dm.ru/olcrtc-xxxxxxxx
+Encryption key: d823fa01cb3e0609b67322f7cf984c4ee2e294936fc24ef38c9e59f4799...
+
+uri: olcrtc://jitsi?datachannel@https://meet.small-dm.ru/olcrtc-xxxxxxxx#<key>$olc - t.me/openlibrecommunity
+```
+
+**Сохрани Room ID и ключ шифрования** - они нужны для клиента. Ключ также сохраняется в `~/.olcrtc_key` и переиспользуется при повторных запусках.
+
+---
+
+## Шаг 3: Запустить клиент
+
+На своей машине (домашний ПК, ноутбук):
 
 ```sh
-./build/olcrtc-linux-amd64 server.yaml
+git clone https://github.com/openlibrecommunity/olcrtc --recurse-submodules
+cd olcrtc
+./script/cnc.sh
 ```
 
-## Запустить клиент
+Отвечай на те же вопросы, что и на сервере - **auth, transport и room ID должны совпадать**. Для jitsi скрипт спросит тот же выбор сервера и имя/URL комнаты.
 
-Создай `client.yaml` на клиентской машине. `auth.provider`, `room.id`, `crypto.key` и `net.transport` должны совпадать с сервером.
+Когда спросит ключ:
 
-> **Важно:** Обязательно проверяйте, есть ли сервис видеозвонков у вас в белых списках, работает ли он и так далее, если нет - используйте другой.
-
-```yaml
-mode: cnc
-auth:
-  provider: jitsi
-room:
-  id: "https://meet.small-dm.ru/REPLACE_ME_WITH_ROOM_ID" # или же https://meet.small-dm.ru/ROOM  или  https://meet1.arbitr.ru/ROOM  или  https://meet.handyweb.org/ROOM и т.д.
-crypto:
-  key: "REPLACE_ME_WITH_64_HEX_CHARS"
-net:
-  transport: datachannel
-  dns: "8.8.8.8:53"
-socks:
-  host: "127.0.0.1"
-  port: 8808
-data: data
+```
+Enter Encryption Key (hex):
 ```
 
-Запусти:
+Вставь ключ с сервера (64 hex-символа).
 
-```sh
-./build/olcrtc-linux-amd64 client.yaml
+### SOCKS5: адрес, порт, аутентификация
+
+```
+SOCKS5 ip [default: 127.0.0.1]:
+SOCKS5 port [default: 8808]:
+SOCKS5 username (leave empty to disable auth):
 ```
 
-После запуска SOCKS5 будет слушать на `127.0.0.1:8808`.
+Жми Enter для адреса и порта - прокси поднимется на `127.0.0.1:8808`. Если нужна защита логином/паролем - введи логин, затем пароль. При биндинге вне loopback (не `127.*`) логин и пароль обязательны.
 
-## Проверить
+### Результат
+
+```
+[+] Client started successfully!
+
+Container name: olcrtc-client-xxxxxxxx
+Auth:           jitsi
+Transport:      datachannel
+Room ID/URL:    https://meet.small-dm.ru/olcrtc-xxxxxxxx
+SOCKS5 proxy:   127.0.0.1:8808
+```
+
+---
+
+## Шаг 4: Проверить
 
 ```sh
 curl --socks5-hostname 127.0.0.1:8808 https://icanhazip.com
 ```
 
-Должен вернуться IP сервера.
+Должен вернуться IP твоего сервера.
+
+Или направить весь трафик через прокси:
+
+```sh
+export all_proxy=socks5h://127.0.0.1:8808
+curl https://icanhazip.com
+```
+
+---
 
 ## Управление
 
-Остановка ручного запуска - `Ctrl+C`.
-
-Если процесс запущен в фоне:
+### Логи
 
 ```sh
-pgrep -af olcrtc
-kill <pid>
+podman ps --filter name=olcrtc
+podman logs -f olcrtc-server-xxxxxxxx   # на сервере
+podman logs -f olcrtc-client-xxxxxxxx   # на клиенте
 ```
 
-Обновление:
+### Остановить
 
 ```sh
-git pull --recurse-submodules
-mage build
+podman stop olcrtc-server-xxxxxxxx
+podman stop olcrtc-client-xxxxxxxx
 ```
 
-Перезапусти сервер и клиент с теми же YAML-конфигами.
+Остановить все olcrtc-контейнеры разом:
 
-## Несколько инстансов
-
-Можно запустить несколько серверов или клиентов на одной машине: создай отдельный YAML для каждого инстанса. Для клиентов используй разные SOCKS5-порты:
-
-```yaml
-socks:
-  host: "127.0.0.1"
-  port: 8809
+```sh
+podman stop $(podman ps -q --filter name=olcrtc)
 ```
 
-Все настройки и матрица совместимости: [settings.md](settings.ru.md). Подробная ручная сборка: [manual.md](manual.ru.md).
+---
+
+## Обновить уже запущенный инстанс
+
+Запущенный контейнер сам не обновляется: внутри него остаётся бинарник, собранный на момент запуска. Чтобы перейти на актуальный код, останови старый контейнер и запусти скрипт заново.
+
+```sh
+cd olcrtc
+git pull --recurse-submodules          # обновить локальные скрипты
+podman stop olcrtc-server-xxxxxxxx     # остановить старый контейнер
+./script/srv.sh --no-cache             # запустить заново со свежим кодом
+```
+
+`--no-cache` не обязателен, но гарантирует пересборку с нуля. При повторном запуске укажи те же `auth`, `transport`, `room ID` и ключ. Серверный ключ хранится в `~/.olcrtc_key` и переиспользуется автоматически.
+
+---
+
+## Несколько инстансов на одной машине
+
+Можно запустить несколько серверов или клиентов на одной машине - каждый запуск создаёт контейнер с уникальным именем (`olcrtc-server-<random>`), они не конфликтуют.
+
+```sh
+./script/srv.sh   # первый инстанс - например jitsi + datachannel
+./script/srv.sh   # второй инстанс - например wbstream + vp8channel
+```
+
+На клиенте для каждого инстанса запускай отдельный `cnc.sh` с **разными SOCKS5-портами**, чтобы переключаться между ними:
+
+```sh
+./script/cnc.sh   # первый клиент - порт 8808 (по умолчанию)
+./script/cnc.sh   # второй клиент - укажи порт 8809
+```
+
+---
+
+Все настройки и матрица совместимости: [settings.ru.md](settings.ru.md). Ручная сборка без скриптов: [manual.ru.md](manual.ru.md).


### PR DESCRIPTION
## Что меняет PR

Переписывает быстрый старт (`docs/fast.md` и `docs/fast.ru.md`) вокруг скриптов `script/srv.sh` и `script/cnc.sh` вместо ручного `mage build`. После коммита 8192802 (удаление Docker) fast-гайд превратился в дубль ручной сборки и дублировал `manual.md`, хотя его смысл - запуск в один скрипт через podman. Текст приведён в соответствие с текущим поведением скриптов: меню выбора Jitsi-сервера, авто-генерация комнаты, дефолты vp8 25/1, запрос комментария к конфигу и вывод `olcrtc://` URI. Ручная сборка остаётся в `manual.md`, на неё стоит ссылка.

## Связанные issue

нет

## Тип изменения

- [x] docs - только документация

## Область

- [x] docs / examples

## Как тестировалось

- Provider: jitsi
- Transport: datachannel
- ОС: linux
- Сценарий:

```text
Сверил каждый шаг гайда с фактическими промптами в script/srv.sh и script/cnc.sh
(carrier/transport/jitsi-server/room/dns/socks/vp8/sei/video/comment, вывод uri).
Проверил, что все внутренние ссылки (manual, settings, asset/gitclone.png) существуют.
Прогнал проверку на em-dash/unicode-стрелки/умные кавычки - чисто, только ASCII.
```

## Совместимость

- [x] Конфиг (`*.yaml`) совместим с предыдущей версией
- [x] Wire-протокол совместим (клиент старой версии работает с новым сервером и наоборот)
- [x] Публичный API в `pkg/` не сломан

## Чек-лист

- [x] Обновлена документация (`docs/`), поведение скриптов не менялось - только гайд
- [x] В коде нет закомментированного мусора, отладочных `fmt.Println`, токенов и ключей
- [x] Я согласен с лицензией репозитория и тем, что мой вклад выпускается под ней
