### PR TITLE
feat(scripts): prompt for wbstream auth.token in srv/cnc

### DIFF
--- a/script/cnc.sh
+++ b/script/cnc.sh
@@ -103,6 +103,14 @@ esac
 echo "[*] Using auth: $AUTH"
 echo ""
 
+WB_TOKEN=""
+if [ "$AUTH" = "wbstream" ]; then
+    echo "wbstream account token (auth.token), optional."
+    echo "Empty = anonymous guest. Required for datachannel (needs moderator rights, canPublishData=true)."
+    read -p "wbstream auth.token (Enter to skip): " WB_TOKEN
+    echo ""
+fi
+
 echo "Select transport:"
 echo "  1) datachannel"
 echo "  2) videochannel"
@@ -363,6 +371,15 @@ cat > "$CONFIG_FILE" <<EOF
 mode: cnc
 auth:
   provider: "$AUTH"
+EOF
+
+if [ -n "$WB_TOKEN" ]; then
+    cat >> "$CONFIG_FILE" <<EOF
+  token: "$WB_TOKEN"
+EOF
+fi
+
+cat >> "$CONFIG_FILE" <<EOF
 room:
   id: "$ROOM_ID"
 crypto:

--- a/script/srv.sh
+++ b/script/srv.sh
@@ -99,6 +99,14 @@ esac
 echo "[*] Using carrier: $CARRIER"
 echo ""
 
+WB_TOKEN=""
+if [ "$CARRIER" = "wbstream" ]; then
+    echo "wbstream account token (auth.token), optional."
+    echo "Empty = anonymous guest. Required for datachannel (needs moderator rights, canPublishData=true)."
+    read -p "wbstream auth.token (Enter to skip): " WB_TOKEN
+    echo ""
+fi
+
 echo "Select transport:"
 echo "  1) datachannel"
 echo "  2) videochannel"
@@ -396,6 +404,15 @@ cat > "$CONFIG_FILE" <<EOF
 mode: srv
 auth:
   provider: "$CARRIER"
+EOF
+
+if [ -n "$WB_TOKEN" ]; then
+    cat >> "$CONFIG_FILE" <<EOF
+  token: "$WB_TOKEN"
+EOF
+fi
+
+cat >> "$CONFIG_FILE" <<EOF
 room:
   id: "$ROOM_ID"
 crypto:


### PR DESCRIPTION
## Что меняет PR

Прокидывает `auth.token` в интерактивные деплой-скрипты `script/srv.sh` и `script/cnc.sh`. Для carrier `wbstream` скрипт спрашивает необязательный токен аккаунта и, если он задан, пишет `auth.token` в сгенерированный yaml. Пусто - прежний guest flow. Сама фича в коде/конфиге/доках уже была (PR #115), скрипты были единственным местом, где поле не предлагалось.

## Связанные issue

Refs #114

## Тип изменения

- [x] feat - новая функциональность

## Область

- [x] config / CLI / URI / sub

## Как тестировалось

- Provider: wbstream
- Transport: datachannel
- ОС: linux
- Сценарий:

```text
bash -n script/srv.sh && bash -n script/cnc.sh - оба OK.
Прогнал heredoc-генерацию yaml для обоих случаев:
- с токеном -> auth: {provider: wbstream, token: ...}
- без токена -> auth: {provider: wbstream}
Оба результата валидный YAML и парсятся в те же поля, что ждёт internal/config (auth.token -> AuthToken).
Промпт показывается только для wbstream, для jitsi/telemost поведение не меняется.
```

## Совместимость

- [x] Конфиг (`*.yaml`) совместим с предыдущей версией
- [x] Wire-протокол совместим (клиент старой версии работает с новым сервером и наоборот)
- [x] Публичный API в `pkg/` не сломан

`auth.token` необязателен, пустое значение сохраняет старое поведение скриптов.

## Чек-лист

- [x] Локально прогнаны `mage lint` и `mage test`
- [x] Добавлены/обновлены тесты, где это имеет смысл
- [x] Обновлена документация (`docs/`, примеры в `docs/examples/`, README), если поведение/конфиг изменились
- [x] В коде нет закомментированного мусора, отладочных `fmt.Println`, токенов и ключей
- [x] Я согласен с лицензией репозитория и тем, что мой вклад выпускается под ней
