### PR TITLE
feat(mobile): pass wbstream auth.token via SetWBToken

### DIFF
--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -84,6 +84,7 @@ type mobileConfig struct {
 	transport        string
 	dnsServer        string
 	socksListenHost  string
+	authToken        string
 	vp8FPS           int
 	vp8BatchSize     int
 	livenessInterval time.Duration
@@ -130,6 +131,17 @@ func SetDNS(dnsServer string) {
 	defer mu.Unlock()
 	ensureDefaultConfigLocked()
 	defaults.dnsServer = dnsServer
+}
+
+// SetWBToken sets the pre-issued wbstream account token (auth.token).
+// When set, the session joins as that account instead of an anonymous guest;
+// empty keeps the guest flow. Required for datachannel over wbstream, which
+// needs an account/moderator token with canPublishData=true.
+func SetWBToken(token string) {
+	mu.Lock()
+	defer mu.Unlock()
+	ensureDefaultConfigLocked()
+	defaults.authToken = strings.TrimSpace(token)
 }
 
 // SetSocksListenHost selects the local bind host for the SOCKS5 listener.
@@ -251,6 +263,7 @@ func Check(
 				DeviceID:  clientID,
 				LocalAddr: socksListenAddr(cfg.socksListenHost, socksPort),
 				DNSServer: defaultDNSServer,
+				AuthToken: cfg.authToken,
 				TransportOptions: vp8channel.Options{
 					FPS:       clampAtLeastOne(vp8FPS, 120),
 					BatchSize: clampAtLeastOne(vp8BatchSize, 64),
@@ -341,6 +354,7 @@ func Ping(
 				DeviceID:  clientID,
 				LocalAddr: socksListenAddr(cfg.socksListenHost, socksPort),
 				DNSServer: defaultDNSServer,
+				AuthToken: cfg.authToken,
 				TransportOptions: vp8channel.Options{
 					FPS:       clampAtLeastOne(vp8FPS, 120),
 					BatchSize: clampAtLeastOne(vp8BatchSize, 64),
@@ -588,6 +602,7 @@ func startWithConfig(
 				DeviceID:  clientID,
 				LocalAddr: socksListenAddr(cfg.socksListenHost, socksPort),
 				DNSServer: cfg.dnsServer,
+				AuthToken: cfg.authToken,
 				SOCKSUser: socksUser,
 				SOCKSPass: socksPass,
 				TransportOptions: vp8channel.Options{

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -208,6 +208,40 @@ func TestStartWithInjectedRunnerLifecycle(t *testing.T) {
 	}
 }
 
+func TestSetWBTokenReachesClientConfig(t *testing.T) {
+	resetMobileGlobals(t)
+	t.Cleanup(func() {
+		resetMobileGlobals(t)
+	})
+
+	SetWBToken("  tok-123  ")
+
+	seen := make(chan string, 1)
+	runClientWithReady = func(ctx context.Context, cfg client.Config, onReady func()) error {
+		seen <- cfg.AuthToken
+		onReady()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	if err := Start(carrierWBStream, testRoomID, "client", "key", 1086, "", ""); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := WaitReady(100); err != nil {
+		t.Fatalf("WaitReady() error = %v", err)
+	}
+	Stop()
+
+	select {
+	case got := <-seen:
+		if got != "tok-123" {
+			t.Fatalf("AuthToken = %q, want %q", got, "tok-123")
+		}
+	default:
+		t.Fatal("Start did not pass AuthToken to client")
+	}
+}
+
 //nolint:cyclop // table-driven test naturally has many branches
 func TestStartUsesDefaultsAndCheckWithInjectedRunner(t *testing.T) {
 	resetMobileGlobals(t)


### PR DESCRIPTION
## Что меняет PR

Пробрасывает `auth.token` в android-прослойку. Раньше `mobile/` всегда собирал `client.Config` без `AuthToken`, поэтому с телефона шёл только guest flow, и `datachannel` поверх `wbstream` не работал (`canPublishData=false`). Теперь добавлен сеттер `SetWBToken(token)`, и токен доезжает до `client.Config.AuthToken` в `Start`/`StartWithTransport`, а также в замерах `Check`/`Ping`. Пусто = прежнее guest-поведение.

## Связанные issue

Refs #114

## Тип изменения

- [x] feat - новая функциональность

## Область

- [x] mobile (`mobile/`)
- [x] auth (`internal/auth/jitsi|telemost|wbstream`)

## Как тестировалось

- Provider: wbstream
- Transport: vp8channel / datachannel
- ОС: android (прослойка)
- Сценарий:

```text
mage check - зелёный (build + golangci-lint v2 0 issues + go test -race, e2e + mobile).
Добавлен TestSetWBTokenReachesClientConfig: SetWBToken(" tok-123 ") -> Start(wbstream)
доезжает до client.Config.AuthToken == "tok-123" (с trim пробелов).
```

## Совместимость

- [x] Конфиг (`*.yaml`) совместим с предыдущей версией
- [x] Wire-протокол совместим (клиент старой версии работает с новым сервером и наоборот)
- [x] Публичный API в `pkg/` не сломан

Сигнатуры `Start`/`StartWithTransport` не изменены - токен задаётся отдельным сеттером `SetWBToken`, поэтому Kotlin/Java-сторона не ломается. Пустой токен сохраняет старое поведение.

## Чек-лист

- [x] Локально прогнаны `mage lint` и `mage test`
- [x] Добавлены/обновлены тесты, где это имеет смысл
- [x] Обновлена документация (`docs/`, примеры в `docs/examples/`, README), если поведение/конфиг изменились
- [x] В коде нет закомментированного мусора, отладочных `fmt.Println`, токенов и ключей
- [x] Я согласен с лицензией репозитория и тем, что мой вклад выпускается под ней
